### PR TITLE
Add redivis mapping

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -23,8 +23,11 @@ AllCops:
 Layout/LineLength:
   Max: 120
 
+Metrics/AbcSize:
+  Max: 18
+
 Metrics/MethodLength:
-  Max: 12
+  Max: 15
 
 RSpec/ExampleLength:
   Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,7 +3,7 @@ plugins:
   - rubocop-rails
   - rubocop-factory_bot
   - rubocop-rspec_rails
-  
+
 AllCops:
   TargetRubyVersion: 3.4
   DisplayCopNames: true
@@ -19,16 +19,19 @@ AllCops:
     - 'config/environments/*.rb'
     - 'db/**/*'
     - 'vendor/**/*'
-  
+
 Layout/LineLength:
   Max: 120
+
+Metrics/MethodLength:
+  Max: 12
 
 RSpec/ExampleLength:
   Enabled: false
 
 RSpec/MultipleExpectations:
   Enabled: false
-  
+
 Style/Documentation:
   Exclude:
     - '**/application*'

--- a/app/services/dataworks_mappers/redivis.rb
+++ b/app/services/dataworks_mappers/redivis.rb
@@ -3,10 +3,70 @@
 module DataworksMappers
   # Map from Redivis metadata to Dataworks metadata
   class Redivis < Base
+    DATE_TYPES = [
+      { key: :temporalRange, type: 'Coverage', epoch: false },
+      { key: :createdAt, type: 'Created', epoch: true }
+    ].freeze
+
+    DESCRIPTION_TYPES = [
+      { key: :description, type: 'Abstract' },
+      { key: :methodologyMarkdown, type: 'Methods' }
+    ].freeze
+
     def perform_map
       {
-        titles: [{ title: source[:name] }]
+        # source_id: source[:qualifiedReference],
+        titles: [{ title: source[:name] }],
+        creators: [{ name: source[:owner][:fullName] }]
+        # resource_type: 'Dataset',
+        # identifier: source[:doi],
+        # identifier_type: 'DOI',
+        # landing_page: source[:url],
+        # access: source[:publicAccessLevel],
+        # size: source[:tableCount], # : source[:totalNumBytes],
+        # variables: tables.variables.name....
+        # tags: source[:tags].map { |tag| { tag: tag[:name] } }
+      }.merge(optional_params)
+    end
+
+    private
+
+    def optional_params
+      {
+        doi: source[:doi],
+        descriptions:,
+        dates:,
+        version: source[:version][:tag]
       }
+    end
+
+    def descriptions
+      [].tap do |descriptions|
+        DESCRIPTION_TYPES.each do |description_type|
+          next unless source[description_type[:key]]
+
+          descriptions << {
+            description: source[description_type[:key]],
+            description_type: description_type[:type]
+          }
+        end
+      end
+    end
+
+    def dates
+      [].tap do |dates|
+        DATE_TYPES.each do |date_type|
+          next unless source[date_type[:key]]
+
+          source_date = source[date_type[:key]]
+          source_date = Time.zone.at(source_date / 1000).strftime('%F') if date_type[:epoch]
+
+          dates << {
+            date: source_date,
+            date_type: date_type[:type]
+          }
+        end
+      end
     end
   end
 end

--- a/spec/factories/dataset_records.rb
+++ b/spec/factories/dataset_records.rb
@@ -7,7 +7,14 @@ FactoryBot.define do
     modified_token { '1.2.3' }
     sequence(:doi) { |n| "doi:10.0000/redivis.abc#{n}" }
     source_md5 { Digest::MD5.hexdigest(source.to_json) }
-    sequence(:source) { |n| { name: "My dataset #{n}" } }
+    sequence(:source) do |n|
+      {
+        name: "My dataset #{n}",
+        owner: { fullName: 'Test Owner' },
+        version: { tag: "v0.#{n}" },
+        doi:
+      }
+    end
     created_at { Time.current }
     updated_at { Time.current }
   end

--- a/spec/factories/dataset_records.rb
+++ b/spec/factories/dataset_records.rb
@@ -12,7 +12,10 @@ FactoryBot.define do
         name: "My dataset #{n}",
         owner: { fullName: 'Test Owner' },
         version: { tag: "v0.#{n}" },
-        doi:
+        doi:,
+        createdAt: 1_574_457_099_929, # Milliseconds since epoch
+        url: "https://example.com/#{doi}",
+        description: 'This is an abstract for the example dataset.'
       }
     end
     created_at { Time.current }

--- a/spec/fixtures/sources/redivis.json
+++ b/spec/fixtures/sources/redivis.json
@@ -39,7 +39,7 @@
   "accessLevel": "data",
   "description": "The Programme for Improving Mental Health Care (PRIME) is creating high quality research evidence on how best to implement and expand the coverage of mental health treatment programmes in low-resource settings. PRIME integrates mental health service delivery into primary health care system in India through a health systems strengthening approach in partnership with researchers, ministries of health and non-governmental organisations.",
   "referenceId": "016c",
-  "temporalRange": null,
+  "temporalRange": [631152000000, 1672531199999],
   "totalNumBytes": 0,
   "usageMarkdown": null,
   "currentVersion": {

--- a/spec/services/dataworks_mappers/redivis_spec.rb
+++ b/spec/services/dataworks_mappers/redivis_spec.rb
@@ -10,7 +10,21 @@ RSpec.describe DataworksMappers::Redivis do
   it 'maps to Redivis metadata' do
     expect(metadata).to eq(
       {
-        titles: [{ title: 'PRIME India' }]
+        doi: '10.57761/m26s-1w59',
+        titles: [{ title: 'PRIME India' }],
+        creators: [{ name: 'Stanford Center for Population Health Sciences' }],
+        descriptions: [{ description: 'The Programme for Improving Mental Health Care ' \
+                                      '(PRIME) is creating high quality research evidence ' \
+                                      'on how best to implement and expand the coverage of ' \
+                                      'mental health treatment programmes in low-resource ' \
+                                      'settings. PRIME integrates mental health service ' \
+                                      'delivery into primary health care system in India ' \
+                                      'through a health systems strengthening approach in ' \
+                                      'partnership with researchers, ministries of health ' \
+                                      'and non-governmental organisations.',
+                         description_type: 'Abstract' }],
+        dates: [{ date: '2019-11-22', date_type: 'Created' }],
+        version: 'v0.1'
       }
     )
   end

--- a/spec/services/dataworks_mappers/redivis_spec.rb
+++ b/spec/services/dataworks_mappers/redivis_spec.rb
@@ -10,9 +10,16 @@ RSpec.describe DataworksMappers::Redivis do
   it 'maps to Redivis metadata' do
     expect(metadata).to eq(
       {
-        doi: '10.57761/m26s-1w59',
         titles: [{ title: 'PRIME India' }],
         creators: [{ name: 'Stanford Center for Population Health Sciences' }],
+        publication_year: '2019',
+        identifiers: [
+          { identifier: '10.57761/m26s-1w59', identifier_type: 'DOI' },
+          { identifier: 'stanfordphs.prime_india:016c:v0_1', identifier_type: 'RedivisReference' }
+        ],
+        url: 'https://redivis.com/datasets/016c-aj7b81qhb?v=0.1',
+        access: 'Public',
+        provider: 'Redivis',
         descriptions: [{ description: 'The Programme for Improving Mental Health Care ' \
                                       '(PRIME) is creating high quality research evidence ' \
                                       'on how best to implement and expand the coverage of ' \
@@ -24,6 +31,8 @@ RSpec.describe DataworksMappers::Redivis do
                                       'and non-governmental organisations.',
                          description_type: 'Abstract' }],
         dates: [{ date: '2019-11-22', date_type: 'Created' }],
+        subjects: [{ subject: 'india' }, { subject: 'mental health' }],
+        sizes: ['0'],
         version: 'v0.1'
       }
     )

--- a/spec/services/dataworks_mappers/redivis_spec.rb
+++ b/spec/services/dataworks_mappers/redivis_spec.rb
@@ -30,9 +30,12 @@ RSpec.describe DataworksMappers::Redivis do
                                       'partnership with researchers, ministries of health ' \
                                       'and non-governmental organisations.',
                          description_type: 'Abstract' }],
-        dates: [{ date: '2019-11-22', date_type: 'Created' }],
+        dates: [
+          { date: '1990-01-01/2022-12-31', date_type: 'Coverage' },
+          { date: '2019-11-22', date_type: 'Created' }
+        ],
         subjects: [{ subject: 'india' }, { subject: 'mental health' }],
-        sizes: ['0'],
+        sizes: ['0 bytes'],
         version: 'v0.1'
       }
     )


### PR DESCRIPTION
Fixes #5 

There are some fields in the spreadsheet that are not yet mapped for redivis, this PR covers all of the fields that have current mappings in the spreadsheet.

Note: I have extracted all of the records from Redivis for SUL, StanfordPHS, and SDSS and run them through this mapper to ensure no errors.