### PR TITLE
Add identifiers to dataworks schema

### DIFF
--- a/config/dataworks_schema.yml
+++ b/config/dataworks_schema.yml
@@ -6,8 +6,6 @@ description: >
   Unless otherwise specified, this schema is based on the DataCite Metadata Schema (https://schema.datacite.org/)
 type: object
 properties:
-  doi:
-    type: string
   creators:
     type: array
     items:
@@ -46,16 +44,21 @@ properties:
     type: string
     pattern: '^[a-zA-Z]{1,8}(-[a-zA-Z0-9]{1,8})*$'
   # Yes, this is plural in the DataCite schema.
-  types:    
+  types:
     $ref: '#/components/schemas/ResourceType'
   version:
     type: string
+  identifiers:
+    type: array
+    items:
+      $ref: '#/components/schemas/Identifier'
+    minItems: 1
 required:
-  # DOI, publisher is required in Datacite, but optional here.
   - titles
   - creators
   - publication_year
   - types
+  - identifiers
 additionalProperties: false
 components:
   schemas:
@@ -102,7 +105,7 @@ components:
           anyOf:
             - format: date-time
             - format: date
-            - pattern: '^[1-2][0-9]{3}(-[0-1][1-9](-[0-3][1-9])?)?/[1-2][0-9]{3}(-[0-1][1-9](-[0-3][1-9])?)?$'            
+            - pattern: '^[1-2][0-9]{3}(-[0-1][1-9](-[0-3][1-9])?)?/[1-2][0-9]{3}(-[0-1][1-9](-[0-3][1-9])?)?$'
         date_type:
           type: string
           enum:
@@ -299,4 +302,19 @@ components:
             - Other
       required:
         - title
+      additionalProperties: false
+    Identifier:
+      type: object
+      properties:
+        identifier:
+          type: string
+        identifier_type:
+          type: string
+          enum:
+            - DOI
+            - RedivisReference
+            - SearchWorksReference
+      required:
+        - identifier
+        - identifier_type
       additionalProperties: false

--- a/spec/services/dataworks_validator_spec.rb
+++ b/spec/services/dataworks_validator_spec.rb
@@ -13,7 +13,8 @@ RSpec.describe DataworksValidator do
         ],
         titles: [{ title: 'My title' }],
         publication_year: '2023',
-        types: { resource_type_general: 'Dataset', resource_type: 'Census' }
+        types: { resource_type_general: 'Dataset', resource_type: 'Census' },
+        identifiers: [{ identifier: '10.1234/5678', identifier_type: 'DOI' }]
       }
     end
 
@@ -29,7 +30,6 @@ RSpec.describe DataworksValidator do
   context 'when metadata is valid' do
     let(:metadata) do
       {
-        doi: '10.1234/5678',
         creators: [
           { name: 'A. Researcher' },
           {
@@ -103,7 +103,11 @@ RSpec.describe DataworksValidator do
         ],
         language: 'en',
         types: { resource_type_general: 'Dataset', resource_type: 'Census' },
-        version: '1.0'
+        version: '1.0',
+        identifiers: [
+          { identifier: 'stanfordphs.prime_india:016c:v0_1', identifier_type: 'RedivisReference' },
+          { identifier: '10.1234/5678', identifier_type: 'DOI' }
+        ]
       }
     end
 
@@ -135,7 +139,7 @@ RSpec.describe DataworksValidator do
           'array size at `/titles` is less than: 1',
           'string at `/publication_year` does not match pattern: ^[1-2][0-9]{3}$',
           'object property at `/another_field` is a disallowed additional property',
-          'object at root is missing required properties: creators, types'
+          'object at root is missing required properties: creators, types, identifiers'
         ]
       )
     end


### PR DESCRIPTION
Adds an Identifier object to support (at least) the redivis use case of redivis having multiple values for `identifier` and `identifier_type`.