### PR TITLE
Remove enum from identifier type in Dataworks schema.

### DIFF
--- a/config/dataworks_schema.yml
+++ b/config/dataworks_schema.yml
@@ -467,10 +467,10 @@ components:
           type: string
         identifier_type:
           type: string
-          enum:
-            - DOI
-            - RedivisReference
-            - SearchWorksReference
+          # Recommended values:
+          #   - DOI
+          #   - RedivisReference
+          #   - SearchWorksReference
       required:
         - identifier
         - identifier_type


### PR DESCRIPTION
This field isn't controlled in DataCite, so mapping would be problematic.