### PR TITLE
Ensure variables are set prior to the super call so they are available

### DIFF
--- a/app/services/clients/redivis.rb
+++ b/app/services/clients/redivis.rb
@@ -4,9 +4,9 @@ module Clients
   # Client for interacting with the Redivis API
   class Redivis < Clients::Base
     def initialize(api_token:, organization:, conn: nil)
-      super(conn:)
       @api_token = api_token
       @organization = organization
+      super(conn:)
     end
 
     # @return [Array<Clients::ListResult>] array of ListResults for the datasets


### PR DESCRIPTION

This is a small tweak to fix a bug I found trying to extract redivis records where the client wasn't getting the api_token because it wasn't set before the call to `new_conn`.