### PR TITLE
Add a Searchworks extractor for use with ICPSR and SDR datasets

### DIFF
--- a/app/services/clients/base.rb
+++ b/app/services/clients/base.rb
@@ -6,7 +6,7 @@ module Clients
   class Error < StandardError; end
 
   # Collection of results returned from Client#list
-  ListResult = Struct.new('ListResult', :id, :modified_token, keyword_init: true)
+  ListResult = Struct.new('ListResult', :id, :modified_token, :source, keyword_init: true)
 
   # Base class for harvesting clients
   class Base

--- a/app/services/clients/datacite.rb
+++ b/app/services/clients/datacite.rb
@@ -37,7 +37,8 @@ module Clients
       results = response_json['data'].map do |dataset_json|
         Clients::ListResult.new(
           id: dataset_json['id'],
-          modified_token: dataset_json.dig('attributes', 'updated')
+          modified_token: dataset_json.dig('attributes', 'updated'),
+          source: nil
         )
       end
       cursor = cursor(link: response_json.dig('links', 'next'))

--- a/app/services/clients/dryad.rb
+++ b/app/services/clients/dryad.rb
@@ -51,7 +51,8 @@ module Clients
       results = response_json.dig('_embedded', 'stash:datasets').map do |dataset_json|
         Clients::ListResult.new(
           id: dataset_json['identifier'],
-          modified_token: dataset_json['versionNumber'].to_s
+          modified_token: dataset_json['versionNumber'].to_s,
+          source: nil
         )
       end
       next_page = response_json.dig('_links', 'next', 'href').present? ? page + 1 : nil

--- a/app/services/clients/redivis.rb
+++ b/app/services/clients/redivis.rb
@@ -44,7 +44,8 @@ module Clients
       results = response_json['results'].map do |dataset_json|
         Clients::ListResult.new(
           id: dataset_json['qualifiedReference'],
-          modified_token: dataset_json['updatedAt'].to_s
+          modified_token: dataset_json['updatedAt'].to_s,
+          source: nil
         )
       end
       [results, response_json['nextPageToken']]

--- a/app/services/clients/zenodo.rb
+++ b/app/services/clients/zenodo.rb
@@ -45,7 +45,8 @@ module Clients
       results = response_json.dig('hits', 'hits').map do |dataset_json|
         Clients::ListResult.new(
           id: dataset_json['id'].to_s,
-          modified_token: dataset_json['revision'].to_s
+          modified_token: dataset_json['revision'].to_s,
+          source: nil
         )
       end
       next_page = response_json.dig('links', 'next').present? ? page + 1 : nil

--- a/app/services/extractors/client_base.rb
+++ b/app/services/extractors/client_base.rb
@@ -36,7 +36,8 @@ module Extractors
     end
 
     def create_dataset_record(result:)
-      source = client.dataset(id: result.id)
+      # If we already have the source use it, otherwise fetch it by ID
+      source = result.source || client.dataset(id: result.id)
       sleep extract_sleep
       DatasetRecord.create!(
         provider:,

--- a/app/services/extractors/searchworks.rb
+++ b/app/services/extractors/searchworks.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module Extractors
+  # Extractor for datasets in Searchworks's Solr index
+  class Searchworks < ClientBase
+    def initialize(list_args:, client: Clients::Solr.new, provider: 'searchworks')
+      super
+      @list_args[:params].merge!(default_solr_params)
+    end
+
+    private
+
+    # Client returns solr docs; we need to map them to ListResults
+    def find_or_create_dataset_record(result:)
+      super(result: doc_to_result(result))
+    end
+
+    # Solr doesn't return marc_json_struct by default, so we ask for it in order
+    # to transform it in the mapper. We also need to ask for last_updated to
+    # use as our modified_token.
+    def default_solr_params
+      {
+        fl: 'id,last_updated,marc_json_struct'
+      }
+    end
+
+    # Map a Solr document into a ListResult
+    def doc_to_result(doc)
+      Clients::ListResult.new(
+        id: doc['id'],
+        modified_token: doc['last_updated'],
+        source: JSON.parse(doc['marc_json_struct'])
+      )
+    end
+
+    # Use the first 856$u we find as the DOI
+    def doi_from(source:)
+      source['fields'].filter_map { |f| f['856'] if f.key? '856' }
+                      .flat_map { |f| f['subfields'] }
+                      .filter { |f| f.key? 'u' }
+                      .pick('u')
+    end
+  end
+end

--- a/spec/services/extractors/searchworks_spec.rb
+++ b/spec/services/extractors/searchworks_spec.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Extractors::Searchworks do
+  let(:example_marc) do
+    {
+      'fields' => [
+        {
+          '856' => {
+            'subfields' => [
+              { 'u' => 'http://doi.org/10.3886/ICPSR37620.v1' }
+            ]
+          }
+        }
+      ]
+    }
+  end
+
+  let(:example_doc) do
+    {
+      'id' => '123',
+      'last_updated' => '2023-01-01T00:00:00Z',
+      'marc_json_struct' => example_marc.to_json
+    }
+  end
+
+  it 'merges default solr params with provided list args' do
+    list_args = { params: { q: 'test' } }
+    client = instance_double(Clients::Solr, list: [], dataset: {})
+    extractor = described_class.new(list_args:, client:)
+    params = extractor.send(:list_args)[:params]
+    expect(params).to include(q: 'test')
+    expect(params).to include(fl: 'id,last_updated,marc_json_struct')
+  end
+
+  it 'maps solr docs into dataset records' do
+    list_args = { params: { q: 'test' } }
+    client = instance_double(Clients::Solr, list: [example_doc], dataset: {})
+    extractor = described_class.new(list_args:, client:)
+    extractor.call
+    record = DatasetRecord.last
+    expect(record.dataset_id).to eq('123')
+    expect(record.modified_token).to eq('2023-01-01T00:00:00Z')
+    expect(record.doi).to eq('http://doi.org/10.3886/ICPSR37620.v1')
+    expect(record.source).to eq(example_marc)
+  end
+
+  context 'when there is no doi in the marc' do
+    let(:example_marc) do
+      {
+        'fields' => [
+          {
+            '856' => {
+              'subfields' => []
+            }
+          }
+        ]
+      }
+    end
+
+    it 'does not error and sets doi to nil' do
+      list_args = { params: { q: 'test' } }
+      client = instance_double(Clients::Solr, list: [example_doc], dataset: {})
+      extractor = described_class.new(list_args:, client:)
+      extractor.call
+      record = DatasetRecord.last
+      expect(record.doi).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
This also makes it so that clients capable of returning the full metadata in a list operation can store it on the `ListResult`, and if present, we can use it without resorting to another HTTP request per item with `Client#dataset`.
