### PR TITLE
using env variable for solr url

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -4,7 +4,7 @@ extract_sleep: 0.5
 dryad_extract_sleep: 2.5
 
 solr:
-  url: http://localhost:8983/solr/dataworks
+  url: <%= ENV['SOLR_URL'] || "http://localhost:8983/solr/dataworks" %>
 
 redivis:
   api_token: ~


### PR DESCRIPTION
Closes #64 

Allows use of environment variable, with default value set.

This also depends on how we want to set up shared configs for the solr url as well, so we may do a direct URL in shared configs