### PR TITLE
fixing fields to be string instead of text

### DIFF
--- a/app/services/solr_mapper.rb
+++ b/app/services/solr_mapper.rb
@@ -25,9 +25,9 @@ class SolrMapper
       descriptions_tsim: descriptions_field,
       doi_ssi: doi_field,
       provider_identifier_ssi: provider_identifier_field,
-      creators_tsim: metadata['creators'].pluck('name'),
+      creators_ssim: metadata['creators'].pluck('name'),
       creators_ids_sim: creators_ids_field,
-      funders_tsim: funders_field,
+      funders_ssim: funders_field,
       funders_ids_sim: funders_ids_field,
       url_ss: metadata['url']
     }.merge(title_fields).compact_blank

--- a/spec/services/solr_mapper_spec.rb
+++ b/spec/services/solr_mapper_spec.rb
@@ -26,9 +26,9 @@ RSpec.describe SolrMapper do
             doi_ssi: '10.1234/5678',
             descriptions_tsim: ['My description', 'My abstract'],
             creators_struct_ss: '[{"name":"A. Researcher"},{"name":"B. Researcher","name_type":"Personal","given_name":"B.","family_name":"Researcher","name_identifiers":[{"name_identifier":"https://orcid.org/0000-0001-2345-6789","name_identifier_scheme":"ORCID"}],"affiliation":[{"name":"My institution","affiliation_identifier":"https://ror.org/00f54p054","affiliation_identifier_scheme":"ROR"}]},{"name":"A. Organization"},{"name":"B. Organization","name_type":"Organizational","name_identifiers":[{"name_identifier":"https://ror.org/00f54p054"}],"affiliation":[{"name":"B. Parent Organization"}]}]',
-            creators_tsim: ['A. Researcher', 'B. Researcher', 'A. Organization', 'B. Organization'],
+            creators_ssim: ['A. Researcher', 'B. Researcher', 'A. Organization', 'B. Organization'],
             creators_ids_sim: ['https://orcid.org/0000-0001-2345-6789', 'https://ror.org/00f54p054'],
-            funders_tsim: ['My funder', 'My other funder'],
+            funders_ssim: ['My funder', 'My other funder'],
             funders_ids_sim: ['https://ror.org/00f54p054'],
             url_ss: 'https://example.com/my-dataset'
           }
@@ -65,7 +65,7 @@ RSpec.describe SolrMapper do
             provider_identifier_ssi: '10.1234/5678',
             doi_ssi: '10.1234/5678',
             creators_struct_ss: '[{"name":"A. Researcher"}]',
-            creators_tsim: ['A. Researcher'],
+            creators_ssim: ['A. Researcher'],
             url_ss: 'https://example.com/my-dataset'
           }
         )


### PR DESCRIPTION
What this PR does:

creators and funders were originally saved as text fields and also added as facet fields.  Being text fields means the values were broken up into tokens for the facets, when we want the entire string as a facet. 