### PR TITLE
Move shared client behavior to the base class

### DIFF
--- a/app/services/clients/datacite.rb
+++ b/app/services/clients/datacite.rb
@@ -3,6 +3,10 @@
 module Clients
   # Client for interacting with the Datacite API
   class Datacite < Clients::Base
+    def initialize(url: 'https://api.datacite.org', conn: nil)
+      super
+    end
+
     # @param affiliation [String] the affiliation to search for (optional)
     # @param page_size [Integer] the number of results to return per page (optional, default: 1000)
     # @param client_id [String] the client ID to use for the request (optional)
@@ -31,17 +35,6 @@ module Clients
     end
 
     private
-
-    def new_conn
-      Faraday.new(
-        url: 'https://api.datacite.org',
-        headers: {
-          'Accept' => 'application/json'
-        }
-      ) do |conn|
-        conn.request :retry, retry_options
-      end
-    end
 
     def list_page(page_size:, cursor: 1)
       response_json = get_json(path: '/dois',

--- a/app/services/clients/dryad.rb
+++ b/app/services/clients/dryad.rb
@@ -3,6 +3,10 @@
 module Clients
   # Client for interacting with the Dryad API
   class Dryad < Clients::Base
+    def initialize(url: 'https://datadryad.org', conn: nil)
+      super
+    end
+
     # @param affiliation [String] the ROR ID of the organization
     # @return [Array<Clients::ListResult>] array of ListResults for the datasets
     # @raise [Clients::Error] if the request fails
@@ -23,17 +27,6 @@ module Clients
     end
 
     private
-
-    def new_conn
-      Faraday.new(
-        url: 'https://datadryad.org',
-        headers: {
-          'Accept' => 'application/json'
-        }
-      ) do |conn|
-        conn.request :retry, retry_options
-      end
-    end
 
     def list_page(affiliation:, per_page:, page:)
       response_json = get_json(path: '/api/v2/search',

--- a/app/services/clients/redivis.rb
+++ b/app/services/clients/redivis.rb
@@ -3,10 +3,9 @@
 module Clients
   # Client for interacting with the Redivis API
   class Redivis < Clients::Base
-    def initialize(api_token:, organization:, conn: nil)
-      @api_token = api_token
+    def initialize(api_token:, organization:, url: 'https://redivis.com', conn: nil)
       @organization = organization
-      super(conn:)
+      super(url: url, api_token: api_token, conn: conn)
     end
 
     # @return [Array<Clients::ListResult>] array of ListResults for the datasets
@@ -26,19 +25,7 @@ module Clients
 
     private
 
-    attr_reader :api_token, :organization
-
-    def new_conn
-      Faraday.new(
-        url: 'https://redivis.com',
-        headers: {
-          'Accept' => 'application/json',
-          'Authorization' => "Bearer #{api_token}"
-        }
-      ) do |conn|
-        conn.request :retry, retry_options
-      end
-    end
+    attr_reader :organization
 
     def list_page(max_results:, page_token: nil)
       response_json = get_json(path: "/api/v1/organizations/#{organization}/datasets",

--- a/app/services/clients/zenodo.rb
+++ b/app/services/clients/zenodo.rb
@@ -3,9 +3,8 @@
 module Clients
   # Client for interacting with the Zenodo API
   class Zenodo < Clients::Base
-    def initialize(api_token:, conn: nil)
-      super(conn:)
-      @api_token = api_token
+    def initialize(api_token:, url: 'https://zenodo.org', conn: nil)
+      super(url: url, api_token: api_token, conn: conn)
     end
 
     # @param affiliation [String] name of the organization
@@ -26,20 +25,6 @@ module Clients
     end
 
     private
-
-    attr_reader :api_token
-
-    def new_conn
-      Faraday.new(
-        url: 'https://zenodo.org',
-        headers: {
-          'Accept' => 'application/json',
-          'Authorization' => "Bearer #{api_token}"
-        }
-      ) do |conn|
-        conn.request :retry, retry_options
-      end
-    end
 
     def list_page(affiliation:, page_size:, page:)
       response_json = get_json(path: '/api/records',

--- a/spec/services/clients/solr_spec.rb
+++ b/spec/services/clients/solr_spec.rb
@@ -15,6 +15,16 @@ RSpec.describe Clients::Solr, :vcr do
   # 5. edit the cassette and change the URL to the production Solr URL
   # 6. disconnect from your ssh tunnel; revert spec/rails_helper.rb changes
 
+  describe 'connection' do
+    it 'does not use the Faraday json middleware' do
+      expect(client.conn.builder.handlers).not_to include(Faraday::Response::Json)
+    end
+
+    it 'uses the FlatParamsEncoder' do
+      expect(client.conn.options.params_encoder).to eq(Faraday::FlatParamsEncoder)
+    end
+  end
+
   describe '.list' do
     subject(:results) { client.list(params:, page_size:).to_a }
 


### PR DESCRIPTION
This cleans up some repeated code around Faraday configuration,
and ensures that all of our clients can inherit automatic retry
behavior.

Most of our new_conn implementations were very similar; the new
Client::Base should cover the vast majority of use cases. It also
provides a single seam to do things like insert logging middleware
on every client request.
