### PR TITLE
Add to ignore list

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -16,9 +16,30 @@ redivis:
 #   ignore:
 #     - ~
 
-# datacite:
-#   ignore:
-#     - ~
+datacite:
+  ignore:
+    - 10.18112/openneuro.ds002732.v1.0.0
+    - 10.18112/openneuro.ds002850.v1.0.0
+    - 10.18112/openneuro.ds002851.v1.0.0
+    - 10.18112/openneuro.ds002852.v1.0.0
+    - 10.18112/openneuro.ds002856.v1.0.0
+    - 10.18112/openneuro.ds002855.v1.0.0
+    - 10.18112/openneuro.ds002858.v1.0.0
+    - 10.18112/openneuro.ds002862.v1.0.0
+    - 10.18112/openneuro.ds002862.v1.0.1
+    - 10.18112/openneuro.ds003122.v1.0.0
+    - 10.18112/openneuro.ds003126.v1.0.0
+    - 10.18112/openneuro.ds003871.v1.0.0
+    - 10.18112/openneuro.ds003871.v1.0.1
+    - 10.18112/openneuro.ds003871.v1.0.2
+    - 10.18112/openneuro.ds004092.v1.0.0
+    - 10.18112/openneuro.ds004092.v1.0.1
+    - 10.18112/openneuro.ds004363.v1.0.0
+    - 10.18112/openneuro.ds004364.v1.0.0
+    - 10.18112/openneuro.ds004367.v1.0.0
+    - 10.18112/openneuro.ds004367.v1.0.1
+    - 10.18112/openneuro.ds004367.v1.0.2
+    - 10.18112/openneuro.ds004373.v1.0.0
 
 # dryad:
 #   ignore:

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -18,28 +18,33 @@ redivis:
 
 datacite:
   ignore:
-    - 10.18112/openneuro.ds002732.v1.0.0
-    - 10.18112/openneuro.ds002850.v1.0.0
-    - 10.18112/openneuro.ds002851.v1.0.0
-    - 10.18112/openneuro.ds002852.v1.0.0
-    - 10.18112/openneuro.ds002856.v1.0.0
-    - 10.18112/openneuro.ds002855.v1.0.0
-    - 10.18112/openneuro.ds002858.v1.0.0
+    - 10.18112/openneuro.ds003871.v1.0.2
+    - 10.18112/openneuro.ds004475.v1.0.3
+    - 10.18112/openneuro.ds004475.v1.0.2
+    - 10.18112/openneuro.ds004475.v1.0.1
+    - 10.18112/openneuro.ds004475.v1.0.0
+    - 10.18112/openneuro.ds004374.v1.0.0
+    - 10.18112/openneuro.ds004373.v1.0.0
+    - 10.18112/openneuro.ds004367.v1.0.2
+    - 10.18112/openneuro.ds004367.v1.0.1
+    - 10.18112/openneuro.ds004367.v1.0.0
+    - 10.18112/openneuro.ds004364.v1.0.0
+    - 10.18112/openneuro.ds004363.v1.0.0
+    - 10.18112/openneuro.ds004092.v1.0.1
+    - 10.18112/openneuro.ds004092.v1.0.0
+    - 10.18112/openneuro.ds003871.v1.0.1
+    - 10.18112/openneuro.ds003871.v1.0.0
+    - 10.18112/openneuro.ds003126.v1.0.0
+    - 10.18112/openneuro.ds003122.v1.0.0
     - 10.18112/openneuro.ds002862.v1.0.0
     - 10.18112/openneuro.ds002862.v1.0.1
-    - 10.18112/openneuro.ds003122.v1.0.0
-    - 10.18112/openneuro.ds003126.v1.0.0
-    - 10.18112/openneuro.ds003871.v1.0.0
-    - 10.18112/openneuro.ds003871.v1.0.1
-    - 10.18112/openneuro.ds003871.v1.0.2
-    - 10.18112/openneuro.ds004092.v1.0.0
-    - 10.18112/openneuro.ds004092.v1.0.1
-    - 10.18112/openneuro.ds004363.v1.0.0
-    - 10.18112/openneuro.ds004364.v1.0.0
-    - 10.18112/openneuro.ds004367.v1.0.0
-    - 10.18112/openneuro.ds004367.v1.0.1
-    - 10.18112/openneuro.ds004367.v1.0.2
-    - 10.18112/openneuro.ds004373.v1.0.0
+    - 10.18112/openneuro.ds002858.v1.0.0
+    - 10.18112/openneuro.ds002852.v1.0.0
+    - 10.18112/openneuro.ds002855.v1.0.0
+    - 10.18112/openneuro.ds002851.v1.0.0
+    - 10.18112/openneuro.ds002856.v1.0.0
+    - 10.18112/openneuro.ds002850.v1.0.0
+    - 10.18112/openneuro.ds002732.v1.0.0
 
 # dryad:
 #   ignore:

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -16,6 +16,7 @@ redivis:
 #   ignore:
 #     - ~
 
+# DataCite has OpenNeuro datasets that do not have title elements and thus cannot validate against our schema
 datacite:
   ignore:
     - 10.18112/openneuro.ds003871.v1.0.2


### PR DESCRIPTION
This PR adds the 27 datasets out of the 4401 datasets retrieved from DataCite's REST API query which do not have a title element within the titles array of objects (i.e. they do not conform to our schema)