### PR TITLE
removing doi: prefix where it exists

### DIFF
--- a/app/services/solr_mapper.rb
+++ b/app/services/solr_mapper.rb
@@ -7,7 +7,7 @@ class SolrMapper
   end
 
   # @param metadata [Hash] the Dataworks metadata
-  # @param doi [String] the DOI, if present, stored in the dataset recordß
+  # @param doi [String] the DOI, if present, stored in the dataset record
   def initialize(metadata:, doi:, dataset_record_id:, dataset_record_set_id:)
     @metadata = metadata.with_indifferent_access
     @doi = doi

--- a/app/services/solr_mapper.rb
+++ b/app/services/solr_mapper.rb
@@ -69,7 +69,8 @@ class SolrMapper
   def doi_field
     return '' unless (identifier = metadata['identifiers'].find { |i| i['identifier_type'] == 'DOI' })
 
-    identifier['identifier']
+    # To standardize the DOI field string between sources, we want to remove any 'doi:' prefix
+    identifier['identifier'].delete_prefix('doi:')
   end
 
   # By default, Solr will throw errors for text fields that are longer than 32,766 characters

--- a/app/services/solr_mapper.rb
+++ b/app/services/solr_mapper.rb
@@ -7,8 +7,10 @@ class SolrMapper
   end
 
   # @param metadata [Hash] the Dataworks metadata
-  def initialize(metadata:, dataset_record_id:, dataset_record_set_id:)
+  # @param doi [String] the DOI, if present, stored in the dataset recordß
+  def initialize(metadata:, doi:, dataset_record_id:, dataset_record_set_id:)
     @metadata = metadata.with_indifferent_access
+    @doi = doi
     @dataset_record_id = dataset_record_id
     @dataset_record_set_id = dataset_record_set_id
   end
@@ -22,7 +24,7 @@ class SolrMapper
       access_ssi: metadata['access'],
       provider_ssi: metadata['provider'],
       descriptions_tsim: descriptions_field,
-      doi_ssi: doi_field,
+      doi_ssi: doi,
       provider_identifier_ssi: provider_identifier_field,
       creators_ssim: person_or_organization_names_field('creators'),
       creators_ids_sim: person_or_organization_ids_field('creators'),
@@ -65,14 +67,6 @@ class SolrMapper
     metadata['identifiers'].find { |i| i['identifier_type'] == provider_ref(metadata['provider']) } ['identifier']
   end
 
-  # Not every dataset will have a DOI provided
-  def doi_field
-    return '' unless (identifier = metadata['identifiers'].find { |i| i['identifier_type'] == 'DOI' })
-
-    # To standardize the DOI field string between sources, we want to remove any 'doi:' prefix
-    identifier['identifier'].delete_prefix('doi:')
-  end
-
   # By default, Solr will throw errors for text fields that are longer than 32,766 characters
   def descriptions_field
     metadata['descriptions']&.filter_map do |d|
@@ -96,7 +90,7 @@ class SolrMapper
 
   private
 
-  attr_reader :metadata, :dataset_record_id, :dataset_record_set_id
+  attr_reader :metadata, :doi, :dataset_record_id, :dataset_record_set_id
 
   # Given titles from metadata, return field value based on title type
   def title_values(title_type, titles)

--- a/app/services/transformer_loader.rb
+++ b/app/services/transformer_loader.rb
@@ -53,7 +53,8 @@ class TransformerLoader
     metadata = mapper.call(source: dataset_record.source)
     check_mapping_success(dataset_record:)
 
-    SolrMapper.call(metadata:, dataset_record_id: dataset_record.id, dataset_record_set_id: dataset_record_set.id)
+    SolrMapper.call(metadata:, doi: dataset_record.doi, dataset_record_id: dataset_record.id,
+                    dataset_record_set_id: dataset_record_set.id)
   rescue DataworksMappers::MappingError => e
     return if ignore?(dataset_record:)
 

--- a/spec/services/solr_mapper_spec.rb
+++ b/spec/services/solr_mapper_spec.rb
@@ -3,7 +3,9 @@
 require 'rails_helper'
 
 RSpec.describe SolrMapper do
-  subject(:solr_mapper) { described_class.new(metadata:, dataset_record_id: 123, dataset_record_set_id: 456) }
+  subject(:solr_mapper) do
+    described_class.new(metadata:, doi: '10.1234/5678', dataset_record_id: 123, dataset_record_set_id: 456)
+  end
 
   context 'with full metadata record' do
     let(:metadata) { JSON.parse(File.read('spec/fixtures/mapped_datasets/full_metadata_mapped.json')) }
@@ -159,33 +161,6 @@ RSpec.describe SolrMapper do
 
       it 'truncates the description string length correctly' do
         expect(solr_mapper.descriptions_field[0].length).to eq(32_766)
-      end
-    end
-  end
-
-  describe '#doi_field' do
-    context 'with no doi prefix in source DOI value' do
-      let(:metadata) do
-        {
-          identifiers: [{ identifier: 'redivis:id', identifier_type: 'Redivis' },
-                        { identifier: '10.1234/5678', identifier_type: 'DOI' }]
-        }
-      end
-
-      it 'retrieves the DOI field' do
-        expect(solr_mapper.doi_field).to eq('10.1234/5678')
-      end
-    end
-
-    context 'with doi prefix in source DOI value' do
-      let(:metadata) do
-        {
-          identifiers: [{ identifier: 'doi:10.1234/5678', identifier_type: 'DOI' }]
-        }
-      end
-
-      it 'retrieves the DOI field' do
-        expect(solr_mapper.doi_field).to eq('10.1234/5678')
       end
     end
   end

--- a/spec/services/solr_mapper_spec.rb
+++ b/spec/services/solr_mapper_spec.rb
@@ -164,15 +164,29 @@ RSpec.describe SolrMapper do
   end
 
   describe '#doi_field' do
-    let(:metadata) do
-      {
-        identifiers: [{ identifier: 'redivis:id', identifier_type: 'Redivis' },
-                      { identifier: '10.1234/5678', identifier_type: 'DOI' }]
-      }
+    context 'with no doi prefix in source DOI value' do
+      let(:metadata) do
+        {
+          identifiers: [{ identifier: 'redivis:id', identifier_type: 'Redivis' },
+                        { identifier: '10.1234/5678', identifier_type: 'DOI' }]
+        }
+      end
+
+      it 'retrieves the DOI field' do
+        expect(solr_mapper.doi_field).to eq('10.1234/5678')
+      end
     end
 
-    it 'retrieves the DOI field' do
-      expect(solr_mapper.doi_field).to eq('10.1234/5678')
+    context 'with doi prefix in source DOI value' do
+      let(:metadata) do
+        {
+          identifiers: [{ identifier: 'doi:10.1234/5678', identifier_type: 'DOI' }]
+        }
+      end
+
+      it 'retrieves the DOI field' do
+        expect(solr_mapper.doi_field).to eq('10.1234/5678')
+      end
     end
   end
 

--- a/spec/services/transformer_loader_spec.rb
+++ b/spec/services/transformer_loader_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe TransformerLoader do
     expect(DataworksMappers::Redivis).to have_received(:call).with(source: dataset_record.source).once
     expect(SolrMapper).to have_received(:call).exactly(3).times
     expect(SolrMapper).to have_received(:call)
-      .with(metadata: Hash, dataset_record_id: dataset_record.id,
+      .with(metadata: Hash, doi: dataset_record.doi, dataset_record_id: dataset_record.id,
             dataset_record_set_id: dataset_record_set.id).once
     expect(solr_service).to have_received(:add).exactly(3).times
     expect(solr_service).to have_received(:commit).once


### PR DESCRIPTION
Closes #130 

Dryad specifically uses "doi:" in their DOI string. While the database tracks the DOIs by removing that prefix, the Solr mapping relies on the source metadata which still uses "doi:" in the prefix. This code ensures such prefixes are removed for the doi_ssi Solr field so all DOIs use a common format. 