### PR TITLE
Remove custom date parsing code in favor of parse_date gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,6 +54,8 @@ gem 'json_schemer' # JSON schema validation
 gem 'marc', '~> 1.3' # For SearchWorks MARC records
 gem 'okcomputer'
 gem 'overmind' # Process manager for running Procfile.dev
+# Getting from GIT temporarily until ownership of the gem is updated so that an update can be released
+gem 'parse_date', git: 'https://github.com/sul-dlss/parse_date'
 gem 'purl_fetcher-client', '~> 3.1' # For SDR datasets
 gem 'rsolr'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,10 @@
+GIT
+  remote: https://github.com/sul-dlss/parse_date
+  revision: a0bf56fc9651e6f8574400795fd67f899a98a254
+  specs:
+    parse_date (0.4.4)
+      zeitwerk (~> 2.1)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -538,6 +545,7 @@ DEPENDENCIES
   mission_control-jobs
   okcomputer
   overmind
+  parse_date!
   pg (~> 1.1)
   propshaft
   puma (>= 5.0)

--- a/app/services/solr_mapper.rb
+++ b/app/services/solr_mapper.rb
@@ -109,20 +109,8 @@ class SolrMapper
   # If the date is a range, store a sequence of years from beginning to end
   def temporal_field
     Array(metadata['dates']).filter_map do |date|
-      next unless date['date_type'] == 'Coverage'
-
-      parse_date(date['date'])
+      ParseDate.parse_range(date['date']) if date['date_type'] == 'Coverage'
     end.flatten
-  end
-
-  # Return an array of dates based on the parsing of the date string
-  def parse_date(date_value)
-    # If this is a range, get the years from beginning to end of the range
-    if date_value.include?('/')
-      date_range_years(date_value)
-    else
-      [date_year(date_value)]
-    end
   end
 
   private
@@ -166,27 +154,6 @@ class SolrMapper
 
   def subjects_field
     metadata['subjects']&.pluck('subject')
-  end
-
-  # A range should be specified as [date]/[date] where date can be in
-  # multiple formats. See dataworks_schema.yml for details.
-  def date_range_years(date_value)
-    return [] unless date_value.split('/').length == 2
-
-    years = date_value.split('/').map do |date_section|
-      date_year(date_section)
-    end
-    # Create range of years including the beginning and end years provided
-    Array(years[0]..years[1])
-  end
-
-  # Retrieve just the year from a particular date string
-  def date_year(date_value)
-    # An allowable schema date format is just the year e.g. '2024'
-    return date_value.to_i if date_value.length == 4
-
-    # Date.parse will work with both 'YYYY-MM-DD' and 'YYYY- MM-DDThh:mm:ssTZD'
-    Date.parse(date_value).year
   end
 
   # Retrieve affiliation name array given either creator or contributor field

--- a/spec/services/solr_mapper_spec.rb
+++ b/spec/services/solr_mapper_spec.rb
@@ -252,16 +252,21 @@ RSpec.describe SolrMapper do
     end
   end
 
-  describe '#parse_dates' do
+  context 'with temporal coverage dates' do
     let(:metadata) do
-      {}
+      {
+        dates: [
+          date:,
+          date_type: 'Coverage'
+        ]
+      }
     end
 
     context 'with YYYY format' do
       let(:date) { '2024' }
 
       it 'returns the year correctly with YYYY format' do
-        expect(solr_mapper.parse_date(date)).to eq([2024])
+        expect(solr_mapper.temporal_field).to eq([2024])
       end
     end
 
@@ -269,7 +274,7 @@ RSpec.describe SolrMapper do
       let(:date) { '2024-02-02' }
 
       it 'returns the year correctly with YYYY format' do
-        expect(solr_mapper.parse_date(date)).to eq([2024])
+        expect(solr_mapper.temporal_field).to eq([2024])
       end
     end
 
@@ -277,7 +282,7 @@ RSpec.describe SolrMapper do
       let(:date) { '2023-01-02T19:20:30+01:00' }
 
       it 'returns the year correctly with YYYY format' do
-        expect(solr_mapper.parse_date(date)).to eq([2023])
+        expect(solr_mapper.temporal_field).to eq([2023])
       end
     end
 
@@ -285,7 +290,7 @@ RSpec.describe SolrMapper do
       let(:date) { '2023-01-02T19:20:30+01:00/2025-01-01' }
 
       it 'returns the sequence of years correctly representing the range' do
-        expect(solr_mapper.parse_date(date)).to eq([2023, 2024, 2025])
+        expect(solr_mapper.temporal_field).to eq([2023, 2024, 2025])
       end
     end
   end


### PR DESCRIPTION
Fixes #146 

This removes the date parsing code in favor of the parse_date gem that already returns the date data in the expected format.