### PR TITLE
Refactor to support deduping.

### DIFF
--- a/app/jobs/datacite_extract_job.rb
+++ b/app/jobs/datacite_extract_job.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-# Job to ETL dataset metadata from DataCite
-class DataciteEtlJob < EtlJob
+# Job to extract dataset metadata from DataCite
+class DataciteExtractJob < ExtractJob
   include Checkinable
 
   def perform(affiliation: nil, client_id: nil)
@@ -9,11 +9,9 @@ class DataciteEtlJob < EtlJob
     dataset_record_set = Extractors::Datacite.call(affiliation:, client_id:)
     dataset_record_set.update!(job_id: @job_id) if @job_id
 
-    Rails.logger.info "DataciteEtlJob complete: DatasetRecordSet #{dataset_record_set.id} - " \
+    Rails.logger.info "DataciteExtractJob complete: DatasetRecordSet #{dataset_record_set.id} - " \
                       "job #{dataset_record_set.job_id} - #{dataset_record_set.provider} - " \
                       "#{dataset_record_set.dataset_records.count} datasets"
-
-    TransformerLoader.call(dataset_record_set:)
   end
 
   def checkin_key

--- a/app/jobs/dryad_extract_job.rb
+++ b/app/jobs/dryad_extract_job.rb
@@ -1,17 +1,15 @@
 # frozen_string_literal: true
 
-# Job to ETL dataset metadata from Dryad
-class DryadEtlJob < EtlJob
+# Job to extract dataset metadata from Dryad
+class DryadExtractJob < ExtractJob
   include Checkinable
 
   def perform
     dataset_record_set = Extractors::Dryad.call
     dataset_record_set.update!(job_id: @job_id) if @job_id
 
-    Rails.logger.info "Dryad complete: DatasetRecordSet #{dataset_record_set.id} - " \
+    Rails.logger.info "DryadExtractJob complete: DatasetRecordSet #{dataset_record_set.id} - " \
                       "job #{dataset_record_set.job_id} - #{dataset_record_set.provider} - " \
                       "#{dataset_record_set.dataset_records.count} datasets"
-
-    TransformerLoader.call(dataset_record_set:)
   end
 end

--- a/app/jobs/etl_job.rb
+++ b/app/jobs/etl_job.rb
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-
-# Base class for jobs to perform ETL
-class EtlJob < ApplicationJob
-  # Sets the job id on the DatasetSourceSet
-  before_perform do |job|
-    @job_id = job.job_id
-  end
-end

--- a/app/jobs/extract_job.rb
+++ b/app/jobs/extract_job.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+# Base class for jobs to perform extract
+class ExtractJob < ApplicationJob
+  # Sets the job id
+  before_perform do |job|
+    @job_id = job.job_id
+  end
+end

--- a/app/jobs/local_extract_job.rb
+++ b/app/jobs/local_extract_job.rb
@@ -1,17 +1,15 @@
 # frozen_string_literal: true
 
-# Job to ETL dataset local metadata
-class LocalEtlJob < EtlJob
+# Job to extract dataset local metadata
+class LocalExtractJob < ExtractJob
   include Checkinable
 
   def perform
     dataset_record_set = Extractors::Local.call
     dataset_record_set.update!(job_id: @job_id) if @job_id
 
-    Rails.logger.info "LocalEtlJob complete: DatasetRecordSet #{dataset_record_set.id} - " \
+    Rails.logger.info "LocalExtractJob complete: DatasetRecordSet #{dataset_record_set.id} - " \
                       "job #{dataset_record_set.job_id} - #{dataset_record_set.provider} - " \
                       "#{dataset_record_set.dataset_records.count} datasets"
-
-    TransformerLoader.call(dataset_record_set:)
   end
 end

--- a/app/jobs/redivis_extract_job.rb
+++ b/app/jobs/redivis_extract_job.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-# Job to ETL dataset metadata from Redivis
-class RedivisEtlJob < EtlJob
+# Job to extract dataset metadata from Redivis
+class RedivisExtractJob < ExtractJob
   include Checkinable
 
   def perform(organization:)
@@ -9,11 +9,9 @@ class RedivisEtlJob < EtlJob
     dataset_record_set = Extractors::Redivis.call(organization:)
     dataset_record_set.update!(job_id: @job_id) if @job_id
 
-    Rails.logger.info "RedivisEtlJob complete: DatasetRecordSet #{dataset_record_set.id} - " \
+    Rails.logger.info "RedivisExtractJob complete: DatasetRecordSet #{dataset_record_set.id} - " \
                       "job #{dataset_record_set.job_id} - #{dataset_record_set.provider} - " \
                       "#{dataset_record_set.dataset_records.count} datasets"
-
-    TransformerLoader.call(dataset_record_set:)
   end
 
   def checkin_key

--- a/app/jobs/searchworks_extract_job.rb
+++ b/app/jobs/searchworks_extract_job.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-# Job to ETL dataset metadata from Searchworks
-class SearchworksEtlJob < EtlJob
+# Job to extract dataset metadata from Searchworks
+class SearchworksExtractJob < ExtractJob
   include Checkinable
 
   def perform(query_label:, solr_params: {})
@@ -9,11 +9,9 @@ class SearchworksEtlJob < EtlJob
     dataset_record_set = Extractors::Searchworks.call(list_args: { params: solr_params })
     dataset_record_set.update!(job_id: @job_id) if @job_id
 
-    Rails.logger.info "SearchworksEtlJob complete: DatasetRecordSet #{dataset_record_set.id} - " \
+    Rails.logger.info "SearchworksExtractJob complete: DatasetRecordSet #{dataset_record_set.id} - " \
                       "job #{dataset_record_set.job_id} - #{dataset_record_set.provider} - " \
                       "#{dataset_record_set.dataset_records.count} datasets"
-
-    TransformerLoader.call(dataset_record_set:)
   end
 
   def checkin_key

--- a/app/jobs/transform_load_job.rb
+++ b/app/jobs/transform_load_job.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+# Job for transforming and loading dataset metadata.
+class TransformLoadJob < ApplicationJob
+  include Checkinable
+
+  # Sets the job id
+  before_perform do |job|
+    @job_id = job.job_id
+  end
+
+  def perform
+    TransformerLoader.call(load_id: @job_id)
+
+    Rails.logger.info "TransformLoadJob complete: job #{@job_id}"
+  end
+end

--- a/app/jobs/zenodo_extract_job.rb
+++ b/app/jobs/zenodo_extract_job.rb
@@ -1,17 +1,15 @@
 # frozen_string_literal: true
 
-# Job to ETL dataset metadata from Zenodo
-class ZenodoEtlJob < EtlJob
+# Job to extract dataset metadata from Zenodo
+class ZenodoExtractJob < ExtractJob
   include Checkinable
 
   def perform
     dataset_record_set = Extractors::Zenodo.call
     dataset_record_set.update!(job_id: @job_id) if @job_id
 
-    Rails.logger.info "ZenodoEtlJob complete: DatasetRecordSet #{dataset_record_set.id} - " \
+    Rails.logger.info "ZenodoExtractJob complete: DatasetRecordSet #{dataset_record_set.id} - " \
                       "job #{dataset_record_set.job_id} - #{dataset_record_set.provider} - " \
                       "#{dataset_record_set.dataset_records.count} datasets"
-
-    TransformerLoader.call(dataset_record_set:)
   end
 end

--- a/app/models/dataset_record.rb
+++ b/app/models/dataset_record.rb
@@ -6,4 +6,9 @@ class DatasetRecord < ApplicationRecord
   has_many :dataset_record_sets, through: :dataset_record_associations
 
   before_save ->(dataset_record) { dataset_record.source_md5 = Digest::MD5.hexdigest(dataset_record.source.to_json) }
+
+  # @return [String] unique identifier for the dataset (independent of the provider)
+  def external_dataset_id
+    doi || [provider, dataset_id].join('-')
+  end
 end

--- a/app/models/dataset_record_set.rb
+++ b/app/models/dataset_record_set.rb
@@ -4,4 +4,8 @@
 class DatasetRecordSet < ApplicationRecord
   has_many :dataset_record_associations, dependent: :destroy
   has_many :dataset_records, through: :dataset_record_associations
+
+  def self.latest_completed(extractor:, list_args:)
+    where(complete: true).where(extractor:).where(list_args:).order(created_at: :desc).first
+  end
 end

--- a/app/services/dataset_transformer_loader.rb
+++ b/app/services/dataset_transformer_loader.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+# Performs transformation from source metadata to Solr documents and loading into Solr for a single dataset
+class DatasetTransformerLoader
+  # These providers are ordered by preference for mapping.
+  PROVIDERS = %w[sdr datacite local searchworks dryad redivis zenodo].freeze
+
+  def self.call(...)
+    new(...).call
+  end
+
+  def initialize(dataset_records:, load_id:, solr: SolrService.new)
+    @dataset_records = dataset_records
+    @solr = solr
+    @load_id = load_id
+  end
+
+  def call
+    # Reloading because the provided DatasetRecord missing the source
+    dataset_record = dataset_records.first.reload
+    solr_doc = solr_doc_for(dataset_record:)
+    solr.add(solr_doc:) if solr_doc
+  end
+
+  private
+
+  attr_reader :solr, :load_id
+
+  # @return [Array<DatasetRecord>] dataset records ordered by provider preference
+  def dataset_records
+    @dataset_records.sort_by do |dataset_record|
+      PROVIDERS.index(dataset_record.provider)
+    end
+  end
+
+  def mapper_for(dataset_record:)
+    "DataworksMappers::#{dataset_record.provider.camelize}".constantize
+  end
+
+  def solr_doc_for(dataset_record:) # rubocop:disable Metrics/AbcSize
+    Honeybadger.context(dataset_record_id: dataset_record.id, provider: dataset_record.provider,
+                        dataset_id: dataset_record.dataset_id)
+    metadata = mapper_for(dataset_record:).call(source: dataset_record.source)
+    check_mapping_success(dataset_record:)
+
+    SolrMapper.call(metadata:, doi: dataset_record.doi, id: dataset_record.external_dataset_id, load_id:)
+  rescue DataworksMappers::MappingError => e
+    return if ignore?(dataset_record:)
+
+    Rails.logger.error "Mapping error for dataset_record_id #{dataset_record.id}: #{e.message}"
+    Honeybadger.notify(e)
+    raise
+  end
+
+  def ignore?(dataset_record:)
+    ignore_dataset_ids(provider: dataset_record.provider).include?(dataset_record.dataset_id)
+  end
+
+  def ignore_dataset_ids(provider:)
+    @ignore_dataset_ids ||= Settings[provider]&.ignore || []
+  end
+
+  def check_mapping_success(dataset_record:)
+    return unless ignore?(dataset_record:)
+
+    msg = "Dataset #{dataset_record.dataset_id} (#{dataset_record.provider}) is ignored but mapping succeeded"
+    Rails.logger.info(msg)
+    Honeybadger.notify(msg)
+  end
+end

--- a/app/services/solr_mapper.rb
+++ b/app/services/solr_mapper.rb
@@ -13,19 +13,21 @@ class SolrMapper
 
   # @param metadata [Hash] the Dataworks metadata
   # @param doi [String] the DOI, if present, stored in the dataset record
-  def initialize(metadata:, doi:, dataset_record_id:, dataset_record_set_id:)
+  # @param id [String] the ID of the dataset
+  # @param load_id [String] the ID of the load
+  def initialize(metadata:, doi:, id:, load_id:)
     @metadata = metadata.with_indifferent_access
     @doi = doi
-    @dataset_record_id = dataset_record_id
-    @dataset_record_set_id = dataset_record_set_id
+    @id = id
+    @load_id = load_id
   end
 
   # @return [Hash] the Solr document
   # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
   def call
     {
-      id: dataset_record_id,
-      dataset_record_set_id_ss: dataset_record_set_id,
+      id:,
+      load_id_ssi: load_id,
       access_ssi: metadata['access'],
       provider_ssi: metadata['provider'],
       descriptions_tsim: descriptions_field,
@@ -121,7 +123,7 @@ class SolrMapper
 
   private
 
-  attr_reader :metadata, :doi, :dataset_record_id, :dataset_record_set_id
+  attr_reader :metadata, :doi, :id, :load_id
 
   # Get the identifier type associated with a particular provider
   def provider_ref(provider)

--- a/app/services/solr_service.rb
+++ b/app/services/solr_service.rb
@@ -10,6 +10,10 @@ class SolrService
     solr.delete_by_id(id)
   end
 
+  def delete_by_query(query:)
+    solr.delete_by_query(query)
+  end
+
   delegate :commit, to: :solr
 
   private

--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -9,42 +9,44 @@
 #     priority: 2
 #     schedule: at 5am every day
 production:
-  # Don't forget to create HB checkins for ETL jobs.
+  # Note that this schedule avoids hitting the same provider concurrently by putting jobs on different days.
+  # Also, this places the transfor and load job after the extract jobs (though there isn't absolutely required).
+  # Don't forget to create HB checkins for jobs.
   redivis_stanfordphs_etl:
-    class: RedivisEtlJob
+    class: RedivisExtractJob
     args: [{ organization: "StanfordPHS" }]
-    schedule: every week
+    schedule: every sunday
   redivis_sul_etl:
-    class: RedivisEtlJob
+    class: RedivisExtractJob
     args: [{ organization: "SUL" }]
-    schedule: every week
+    schedule: every monday
   redivis_sdss_etl:
-    class: RedivisEtlJob
+    class: RedivisExtractJob
     args: [{ organization: "SDSS" }]
-    schedule: every week
+    schedule: every tuesday
   datacite_affiliation_etl:
-    class: DataciteEtlJob
+    class: DataciteExtractJob
     args: [{ affiliation: "Stanford University" }]
-    schedule: every week
-  datacite_provider_etl:
-    class: DataciteEtlJob
-    args: [{ provider_id: "sul" }]
-    schedule: every week    
+    schedule: every sunday
   open_neuro_etl:
-    class: DataciteEtlJob
+    class: DataciteExtractJob
     args: [{ client_id: "sul.openneuro" }]
-    schedule: every week
+    schedule: every monday
+  datacite_provider_etl:
+    class: DataciteExtractJob
+    args: [{ provider_id: "sul" }]
+    schedule: every tuesday  
   zenodo_etl:
-    class: ZenodoEtlJob
-    schedule: every week
+    class: ZenodoExtractJob
+    schedule: every sunday
   local_etl:
-    class: LocalEtlJob
-    schedule: every week
+    class: LocalExtractJob
+    schedule: every sunday
   dryad_etl:
-    class: DryadEtlJob
-    schedule: every week
+    class: DryadExtractJob
+    schedule: every sunday
   icpsr_etl:
-    class: SearchworksEtlJob
+    class: SearchworksExtractJob
     args:
       [
         {
@@ -57,4 +59,7 @@ production:
             },
         },
       ]
-    schedule: every week
+    schedule: every sunday
+  tl:
+    class: TransformLoadJob
+    schedule: every thursday

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -66,13 +66,14 @@ dor_services:
   token: ~
 
 honeybadger:
-  datacite_etl_job_stanford_university_checkin: ~
-  datacite_etl_job_sul_checkin: ~
-  datacite_etl_job_sul_openneuro_checkin: ~
-  zenodo_etl_job_checkin: ~
-  redivis_etl_job_stanfordphs_checkin: ~
-  redivis_etl_job_sul_checkin: ~
-  redivis_etl_job_sdss_checkin: ~
-  local_etl_job_checkin: ~
-  dryad_etl_job_checkin: ~
-  searchworks_etl_job_icpsr_checkin: ~
+  datacite_extract_job_stanford_university_checkin: ~
+  datacite_extract_job_sul_openneuro_checkin: ~
+  datacite_extract_job_sul_checkin: ~
+  zenodo_extract_job_checkin: ~
+  redivis_extract_job_stanfordphs_checkin: ~
+  redivis_extract_job_sul_checkin: ~
+  redivis_extract_job_sdss_checkin: ~
+  local_extract_job_checkin: ~
+  dryad_extract_job_checkin: ~
+  searchworks_extract_job_icpsr_checkin: ~
+  transform_load_job_checkin: ~

--- a/spec/factories/dataset_record_sets.rb
+++ b/spec/factories/dataset_record_sets.rb
@@ -13,7 +13,7 @@ FactoryBot.define do
         dataset_records_count { 3 }
       end
 
-      dataset_records { create_list(:dataset_record, dataset_records_count) }
+      dataset_records { create_list(:dataset_record, dataset_records_count, provider:) }
     end
   end
 end

--- a/spec/factories/dataset_records.rb
+++ b/spec/factories/dataset_records.rb
@@ -5,7 +5,7 @@ FactoryBot.define do
     provider { 'redivis' }
     sequence(:dataset_id) { |n| "abc#{n}" }
     modified_token { '1.2.3' }
-    sequence(:doi) { |n| "doi:10.0000/redivis.abc#{n}" }
+    sequence(:doi) { |n| "doi:10.0000/#{provider}.abc#{n}" }
     source_md5 { Digest::MD5.hexdigest(source.to_json) }
     sequence(:source) do |n|
       {

--- a/spec/jobs/datacite_extract_job_spec.rb
+++ b/spec/jobs/datacite_extract_job_spec.rb
@@ -2,21 +2,19 @@
 
 require 'rails_helper'
 
-RSpec.describe DataciteEtlJob do
+RSpec.describe DataciteExtractJob do
   let(:job) { described_class }
 
   let(:dataset_record_set) { create(:dataset_record_set, provider: 'datacite') }
 
   before do
     allow(Extractors::Datacite).to receive(:call).and_return(dataset_record_set)
-    allow(TransformerLoader).to receive(:call)
   end
 
-  it 'performs transform and load' do
+  it 'performs extract' do
     described_class.perform_now
 
     expect(dataset_record_set.reload.job_id).not_to be_nil
     expect(Extractors::Datacite).to have_received(:call)
-    expect(TransformerLoader).to have_received(:call).with(dataset_record_set:)
   end
 end

--- a/spec/jobs/dryad_extract_job_spec.rb
+++ b/spec/jobs/dryad_extract_job_spec.rb
@@ -2,21 +2,19 @@
 
 require 'rails_helper'
 
-RSpec.describe DryadEtlJob do
+RSpec.describe DryadExtractJob do
   let(:job) { described_class }
 
   let(:dataset_record_set) { create(:dataset_record_set, provider: 'dryad') }
 
   before do
     allow(Extractors::Dryad).to receive(:call).and_return(dataset_record_set)
-    allow(TransformerLoader).to receive(:call)
   end
 
-  it 'performs transform and load' do
+  it 'performs extract' do
     described_class.perform_now
 
     expect(dataset_record_set.reload.job_id).not_to be_nil
     expect(Extractors::Dryad).to have_received(:call)
-    expect(TransformerLoader).to have_received(:call).with(dataset_record_set:)
   end
 end

--- a/spec/jobs/local_extract_job_spec.rb
+++ b/spec/jobs/local_extract_job_spec.rb
@@ -2,21 +2,19 @@
 
 require 'rails_helper'
 
-RSpec.describe LocalEtlJob do
+RSpec.describe LocalExtractJob do
   let(:job) { described_class }
 
   let(:dataset_record_set) { create(:dataset_record_set, provider: 'local') }
 
   before do
     allow(Extractors::Local).to receive(:call).and_return(dataset_record_set)
-    allow(TransformerLoader).to receive(:call)
   end
 
-  it 'performs transform and load' do
+  it 'performs textract' do
     described_class.perform_now
 
     expect(dataset_record_set.reload.job_id).not_to be_nil
     expect(Extractors::Local).to have_received(:call)
-    expect(TransformerLoader).to have_received(:call).with(dataset_record_set:)
   end
 end

--- a/spec/jobs/redivis_extract_job_spec.rb
+++ b/spec/jobs/redivis_extract_job_spec.rb
@@ -2,21 +2,19 @@
 
 require 'rails_helper'
 
-RSpec.describe RedivisEtlJob do
+RSpec.describe RedivisExtractJob do
   let(:job) { described_class }
 
   let(:dataset_record_set) { create(:dataset_record_set) }
 
   before do
     allow(Extractors::Redivis).to receive(:call).and_return(dataset_record_set)
-    allow(TransformerLoader).to receive(:call)
   end
 
-  it 'performs transform and load' do
+  it 'performs extract' do
     described_class.perform_now(organization: 'StanfordPHS')
 
     expect(dataset_record_set.reload.job_id).not_to be_nil
     expect(Extractors::Redivis).to have_received(:call).with(organization: 'StanfordPHS')
-    expect(TransformerLoader).to have_received(:call).with(dataset_record_set:)
   end
 end

--- a/spec/jobs/searchworks_extract_job_spec.rb
+++ b/spec/jobs/searchworks_extract_job_spec.rb
@@ -2,21 +2,19 @@
 
 require 'rails_helper'
 
-RSpec.describe SearchworksEtlJob do
+RSpec.describe SearchworksExtractJob do
   let(:job) { described_class }
 
   let(:dataset_record_set) { create(:dataset_record_set) }
 
   before do
     allow(Extractors::Searchworks).to receive(:call).and_return(dataset_record_set)
-    allow(TransformerLoader).to receive(:call)
   end
 
-  it 'performs transform and load' do
+  it 'performs extract' do
     described_class.perform_now(solr_params: { q: 'test', rows: 10 }, query_label: 'My Test Query')
 
     expect(dataset_record_set.reload.job_id).not_to be_nil
     expect(Extractors::Searchworks).to have_received(:call).with(list_args: { params: { q: 'test', rows: 10 } })
-    expect(TransformerLoader).to have_received(:call).with(dataset_record_set:)
   end
 end

--- a/spec/jobs/transform_load_job_spec.rb
+++ b/spec/jobs/transform_load_job_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe TransformLoadJob do
+  let(:job) { described_class }
+
+  let(:dataset_record_set) { create(:dataset_record_set) }
+
+  before do
+    allow(TransformerLoader).to receive(:call)
+  end
+
+  it 'performs extract' do
+    described_class.perform_now
+
+    expect(TransformerLoader).to have_received(:call).with(load_id: String)
+  end
+end

--- a/spec/jobs/zenodo_extract_job_spec.rb
+++ b/spec/jobs/zenodo_extract_job_spec.rb
@@ -2,21 +2,19 @@
 
 require 'rails_helper'
 
-RSpec.describe ZenodoEtlJob do
+RSpec.describe ZenodoExtractJob do
   let(:job) { described_class }
 
   let(:dataset_record_set) { create(:dataset_record_set) }
 
   before do
     allow(Extractors::Zenodo).to receive(:call).and_return(dataset_record_set)
-    allow(TransformerLoader).to receive(:call)
   end
 
-  it 'performs transform and load' do
+  it 'performs extract' do
     described_class.perform_now
 
     expect(dataset_record_set.reload.job_id).not_to be_nil
     expect(Extractors::Zenodo).to have_received(:call)
-    expect(TransformerLoader).to have_received(:call).with(dataset_record_set:)
   end
 end

--- a/spec/services/dataset_transformer_loader_spec.rb
+++ b/spec/services/dataset_transformer_loader_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe DatasetTransformerLoader do
+  let(:dataset_record) { create(:dataset_record) }
+
+  let(:solr_service) { instance_double(SolrService, add: true) }
+  let(:zenodo_dataset_record) { instance_double(DatasetRecord, provider: 'zenodo') }
+  let(:load_id) { 'abc123' }
+
+  before do
+    allow(SolrService).to receive(:new).and_return(solr_service)
+    allow(DataworksMappers::Redivis).to receive(:call).and_call_original
+    allow(SolrMapper).to receive(:call).and_call_original
+  end
+
+  it 'transforms and loads' do
+    described_class.call(dataset_records: [zenodo_dataset_record, dataset_record], load_id:)
+    expect(DataworksMappers::Redivis).to have_received(:call).with(source: dataset_record.source).once
+    expect(SolrMapper).to have_received(:call)
+      .with(metadata: Hash, doi: dataset_record.doi, id: dataset_record.doi, load_id:).once
+    expect(solr_service).to have_received(:add).once
+  end
+
+  context 'when there is an error in mapping' do
+    before do
+      allow(DataworksMappers::Redivis).to receive(:call).and_raise(DataworksMappers::MappingError)
+    end
+
+    it 'raises an error' do
+      expect do
+        described_class.call(dataset_records: [zenodo_dataset_record, dataset_record], load_id:)
+      end.to raise_error(DataworksMappers::MappingError)
+      expect(SolrMapper).not_to have_received(:call)
+    end
+  end
+
+  context 'when there is an error in mapping but dataset is ignored' do
+    before do
+      allow(DataworksMappers::Redivis).to receive(:call)
+        .with(source: dataset_record.source).and_raise(DataworksMappers::MappingError)
+      allow(Settings.redivis).to receive(:ignore).and_return([dataset_record.dataset_id])
+    end
+
+    it 'ignores the error' do
+      described_class.call(dataset_records: [zenodo_dataset_record, dataset_record], load_id:)
+      expect(solr_service).not_to have_received(:add)
+    end
+  end
+
+  context 'when there is an ignored dataset that does not raise' do
+    before do
+      allow(Settings.redivis).to receive(:ignore).and_return([dataset_record.dataset_id])
+      allow(Honeybadger).to receive(:notify)
+    end
+
+    it 'notifies Honeybadger' do
+      described_class.call(dataset_records: [zenodo_dataset_record, dataset_record], load_id:)
+      expect(solr_service).to have_received(:add).once
+      expect(Honeybadger).to have_received(:notify).with(/is ignored but mapping succeeded/)
+    end
+  end
+end

--- a/spec/services/solr_mapper_spec.rb
+++ b/spec/services/solr_mapper_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe SolrMapper do
   subject(:solr_mapper) do
-    described_class.new(metadata:, doi: '10.1234/5678', dataset_record_id: 123, dataset_record_set_id: 456)
+    described_class.new(metadata:, doi: '10.1234/5678', id: 'revidis-123', load_id: 'abc123')
   end
 
   context 'with full metadata record' do
@@ -15,8 +15,8 @@ RSpec.describe SolrMapper do
       it 'maps to Solr metadata' do
         expect(solr_mapper.call).to eq(
           {
-            id: 123,
-            dataset_record_set_id_ss: 456,
+            id: 'revidis-123',
+            load_id_ssi: 'abc123',
             title_tsim: ['My title V1.0'],
             subtitle_tsim: ['My subtitle'],
             alternative_title_tsim: ['My alt title'],
@@ -76,8 +76,8 @@ RSpec.describe SolrMapper do
       it 'maps to Solr metadata' do
         expect(solr_mapper.call).to eq(
           {
-            id: 123,
-            dataset_record_set_id_ss: 456,
+            id: 'revidis-123',
+            load_id_ssi: 'abc123',
             title_tsim: ['My title'],
             access_ssi: 'Public',
             provider_ssi: 'DataCite',

--- a/spec/services/solr_service_spec.rb
+++ b/spec/services/solr_service_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe SolrService do
   let(:solr_service) { described_class.new }
 
-  let(:rsolr) { instance_double(RSolr::Client, commit: true, add: true, delete_by_id: true) }
+  let(:rsolr) { instance_double(RSolr::Client, commit: true, add: true, delete_by_id: true, delete_by_query: true) }
 
   before do
     allow(RSolr).to receive(:connect).and_return(rsolr)
@@ -33,6 +33,15 @@ RSpec.describe SolrService do
     it 'deletes a document from Solr' do
       solr_service.delete(id: document_id)
       expect(rsolr).to have_received(:delete_by_id).with(document_id)
+    end
+  end
+
+  describe '#delete_by_query' do
+    let(:query) { 'title:"Test Document"' }
+
+    it 'deletes documents from Solr by query' do
+      solr_service.delete_by_query(query: query)
+      expect(rsolr).to have_received(:delete_by_query).with(query)
     end
   end
 end


### PR DESCRIPTION
closes #90

This approach separates extraction from transform and load.

Assuming that extraction has been performed: For each extractor / list args, get the latest completed DatasetRecordSets. Group all of the DatasetRecords for these DatasetRecord by DOI or provider / dataset id. For each group of DatasetRecords, select the preferred DatasetRecord and map and add to solr, using the DOI or provider / dataset id as the Solr doc id and including a load id for the load. Delete any Solr records that are associated with a different load id. 