### PR TITLE
changing local provider so identifier parsing works correctly

### DIFF
--- a/config/local_datasets/example.yml
+++ b/config/local_datasets/example.yml
@@ -75,7 +75,7 @@ dates:
 language: en
 identifiers:
 - identifier: stanfordphs.prime_india:016c:v0_1
-  identifier_type: RedivisReference
+  identifier_type: LocalReference
 - identifier: 10.1234/5678
   identifier_type: DOI
 related_identifiers:


### PR DESCRIPTION
What this PR does:

Solr mapping was running into an error because our logic for the main provider identifier based on the identifier type.  In the example case, with the "Local" provider, the identifier type should be "LocalReference" to prevent errors. 