### PR TITLE
adding SDR provider and DRUID recognition to Solr mapping

### DIFF
--- a/app/services/solr_mapper.rb
+++ b/app/services/solr_mapper.rb
@@ -137,6 +137,8 @@ class SolrMapper
       'DOI'
     when 'Zenodo'
       'ZenodoId'
+    when 'SDR'
+      'DRUID'
     else
       "#{provider}Reference"
     end

--- a/spec/services/solr_mapper_spec.rb
+++ b/spec/services/solr_mapper_spec.rb
@@ -137,12 +137,12 @@ RSpec.describe SolrMapper do
       let(:metadata) do
         {
           provider: 'SDR',
-          identifiers: [{ identifier: '10.1234/5678', identifier_type: 'DRUID' }]
+          identifiers: [{ identifier: 'druid:123ab456', identifier_type: 'DRUID' }]
         }
       end
 
       it 'retrieves the SDR DRUID' do
-        expect(solr_mapper.provider_identifier_field).to eq('10.1234/5678')
+        expect(solr_mapper.provider_identifier_field).to eq('druid:123ab456')
       end
     end
   end

--- a/spec/services/solr_mapper_spec.rb
+++ b/spec/services/solr_mapper_spec.rb
@@ -132,6 +132,19 @@ RSpec.describe SolrMapper do
         expect(solr_mapper.provider_identifier_field).to eq('10.1234/5678')
       end
     end
+
+    context 'with SDR as provider' do
+      let(:metadata) do
+        {
+          provider: 'SDR',
+          identifiers: [{ identifier: '10.1234/5678', identifier_type: 'DRUID' }]
+        }
+      end
+
+      it 'retrieves the SDR DRUID' do
+        expect(solr_mapper.provider_identifier_field).to eq('10.1234/5678')
+      end
+    end
   end
 
   describe '#descriptions_field' do


### PR DESCRIPTION
Solr mapping needs to recognize that, for SDR as a provider, the identifier type it needs to look for is "DRUID"