### PR TITLE
Ensure that solr crawl params can be overridden in SW extractor

### DIFF
--- a/app/services/extractors/searchworks.rb
+++ b/app/services/extractors/searchworks.rb
@@ -6,7 +6,7 @@ module Extractors
     def initialize(list_args:, client: Clients::Solr.new, provider: 'searchworks',
                    extra_dataset_ids: YAML.load_file('config/datasets/searchworks.yml'))
       super
-      @list_args[:params].merge!(default_solr_params)
+      @list_args[:params].reverse_merge!(default_solr_params)
     end
 
     private


### PR DESCRIPTION
This swaps the order of hash merging so that it's actually possible
to pass a different `fl`, which is useful when testing things out
locally.
