### PR TITLE
Add geo_location to dataworks schema

### DIFF
--- a/app/services/dataworks_mappers/datacite.rb
+++ b/app/services/dataworks_mappers/datacite.rb
@@ -23,7 +23,8 @@ module DataworksMappers
         funding_references:,
         url: attrs[:url],
         access: 'Public', # TODO: Hardcoded for now, but needs additional consideration
-        provider: 'DataCite'
+        provider: 'DataCite',
+        geo_locations:
       }.compact_blank
     end
 
@@ -91,6 +92,18 @@ module DataworksMappers
       date.sub!(' to ', '/')
       date << 'Z' if date.match?(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}$/)
       date
+    end
+
+    def geo_locations
+      return unless attrs[:geoLocations]
+
+      attrs[:geoLocations].filter_map do |geo_location|
+        next if geo_location[:geoLocationPlace].blank?
+
+        {
+          geo_location_place: geo_location[:geoLocationPlace]
+        }.compact
+      end
     end
 
     def identifiers

--- a/app/services/dataworks_mappers/dryad.rb
+++ b/app/services/dataworks_mappers/dryad.rb
@@ -23,7 +23,7 @@ module DataworksMappers
       'crossref_funder_id' => 'Crossref Funder ID'
     }.freeze
 
-    def perform_map
+    def perform_map # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
       {
         titles: [{ title: source[:title] }],
         creators:,
@@ -34,6 +34,7 @@ module DataworksMappers
         provider: 'Dryad',
         descriptions:,
         dates:,
+        geo_locations:,
         subjects:,
         sizes:,
         funding_references:,
@@ -126,6 +127,18 @@ module DataworksMappers
 
           identifiers << { identifier: source[identifier_type[:key]], identifier_type: identifier_type[:type] }
         end
+      end
+    end
+
+    def geo_locations
+      return unless source[:locations]
+
+      source[:locations].filter_map do |location|
+        next if location[:place].blank?
+
+        {
+          geo_location_place: location[:place]
+        }.compact
       end
     end
 

--- a/app/services/solr_mapper.rb
+++ b/app/services/solr_mapper.rb
@@ -59,6 +59,7 @@ class SolrMapper
       variables_tsim: metadata['variables'],
       temporal_isim: temporal_field,
       courses_sim: courses,
+      geo_place_ssim: geo_locations_field,
       provider_identifier_map_struct_ss: provider_identifiers_map.presence&.to_json
     }.merge(title_fields).merge(struct_fields).compact_blank
   end
@@ -173,6 +174,10 @@ class SolrMapper
 
   def subjects_field
     metadata['subjects']&.pluck('subject')
+  end
+
+  def geo_locations_field
+    metadata['geo_locations']&.pluck('geo_location_place')
   end
 
   # Retrieve affiliation name array given either creator or contributor field

--- a/config/dataworks_schema.yml
+++ b/config/dataworks_schema.yml
@@ -108,6 +108,12 @@ properties:
       - Zenodo
       - SearchWorks
       - SDR
+  geo_locations:
+    description: A list of geographic locations relevant to the dataset
+    type: array
+    items:
+      $ref: '#/components/schemas/GeoLocation'
+    minItems: 1
 required:
   - titles
   - publication_year
@@ -233,7 +239,7 @@ components:
       dependentRequired:
         funder_identifier:
           - funder_identifier_type
-      additionalProperties: false    
+      additionalProperties: false
     PersonOrOrganization:
       type: object
       properties:
@@ -521,4 +527,12 @@ components:
       required:
         - identifier
         - identifier_type
+      additionalProperties: false
+    GeoLocation:
+      type: object
+      properties:
+        geo_location_place:
+          type: string
+      required:
+        - geo_location_place
       additionalProperties: false

--- a/spec/fixtures/mapped_datasets/full_metadata_mapped.json
+++ b/spec/fixtures/mapped_datasets/full_metadata_mapped.json
@@ -226,5 +226,13 @@
   ],
   "data_use_statement": "My data use statement",
   "access": "Restricted",
-  "provider": "Redivis"
+  "provider": "Redivis",
+  "geo_locations": [
+    {
+      "geo_location_place": "Vancouver, British Columbia, Canada"
+    },
+    {
+      "geo_location_place": "Victoria, British Columbia, Canada"
+    }
+  ]
 }

--- a/spec/fixtures/sources/dryad.json
+++ b/spec/fixtures/sources/dryad.json
@@ -61,6 +61,11 @@
   "keywords": [
     "Geomorphology and cosmogenic radionuclides"
   ],
+  "locations": [
+    {
+      "place": "Apalachicola River basin, Florida"
+    }
+  ],
   "methods": "TEST METHODS",
   "usageNotes": "TEST USAGE NOTES",
   "versionNumber": 3,

--- a/spec/services/dataworks_mappers/datacite_spec.rb
+++ b/spec/services/dataworks_mappers/datacite_spec.rb
@@ -480,6 +480,11 @@ RSpec.describe DataworksMappers::Datacite do
             rights_identifier_scheme: 'SPDX'
           }
         ],
+        geo_locations: [
+          {
+            geo_location_place: 'Vancouver, British Columbia, Canada'
+          }
+        ],
         funding_references: [
           {
             award_uri: 'https://example.com/example-award-uri',

--- a/spec/services/dataworks_mappers/dryad_spec.rb
+++ b/spec/services/dataworks_mappers/dryad_spec.rb
@@ -76,6 +76,7 @@ RSpec.describe DataworksMappers::Dryad do
             funder_name: 'National Science Foundation'
           }
         ],
+        geo_locations: [{ geo_location_place: 'Apalachicola River basin, Florida' }],
         version: '3'
       }
     )

--- a/spec/services/solr_mapper_spec.rb
+++ b/spec/services/solr_mapper_spec.rb
@@ -65,7 +65,8 @@ RSpec.describe SolrMapper do
             variables_tsim: ['variable 1', 'variable 2'],
             temporal_isim: [2022],
             courses_sim: ['CS246'],
-            provider_identifier_map_struct_ss: '{"DataCite":"10.1234/5678","Redivis":"redivis-123"}'
+            provider_identifier_map_struct_ss: '{"DataCite":"10.1234/5678","Redivis":"redivis-123"}',
+            geo_place_ssim: ['Vancouver, British Columbia, Canada', 'Victoria, British Columbia, Canada']
           }
         )
       end


### PR DESCRIPTION
Fixes #213 

This adds the geo_location field to the schema and solr mapping. Implementing the data for datacite and dryad.