### PR TITLE
Update dependencies and match new cop

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -159,7 +159,7 @@ GEM
       faraday (~> 2.0)
       faraday-retry
       zeitwerk (~> 2.1)
-    drb (2.2.1)
+    drb (2.2.3)
     dry-core (1.1.0)
       concurrent-ruby (~> 1.0)
       logger
@@ -187,6 +187,7 @@ GEM
       activesupport (>= 3.0, < 9.0)
     equivalent-xml (0.6.0)
       nokogiri (>= 1.4.3)
+    erb (5.0.1)
     erubi (1.13.1)
     et-orbi (1.2.11)
       tzinfo
@@ -211,7 +212,7 @@ GEM
     globalid (1.2.1)
       activesupport (>= 6.1)
     hana (1.3.7)
-    hashdiff (1.1.2)
+    hashdiff (1.2.0)
     honeybadger (5.28.0)
       logger
       ostruct
@@ -360,7 +361,7 @@ GEM
       activesupport (= 8.0.2)
       bundler (>= 1.15.0)
       railties (= 8.0.2)
-    rails-dom-testing (2.2.0)
+    rails-dom-testing (2.3.0)
       activesupport (>= 5.0.0)
       minitest
       nokogiri (>= 1.6)
@@ -377,7 +378,8 @@ GEM
       zeitwerk (~> 2.6)
     rainbow (3.1.1)
     rake (13.2.1)
-    rdoc (6.13.1)
+    rdoc (6.14.0)
+      erb
       psych (>= 4.0.0)
     regexp_parser (2.10.0)
     reline (0.6.1)
@@ -407,7 +409,7 @@ GEM
       rspec-mocks (~> 3.13)
       rspec-support (~> 3.13)
     rspec-support (3.13.3)
-    rubocop (1.75.6)
+    rubocop (1.75.7)
       json (~> 2.3)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.1.0)
@@ -508,7 +510,7 @@ GEM
       base64
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    zeitwerk (2.7.2)
+    zeitwerk (2.7.3)
 
 PLATFORMS
   aarch64-linux

--- a/app/services/solr_mapper.rb
+++ b/app/services/solr_mapper.rb
@@ -71,7 +71,7 @@ class SolrMapper
 
   # Retrieve the identifier used by the provider themselves
   def provider_identifier_field
-    metadata['identifiers'].find { |i| i['identifier_type'] == provider_ref(metadata['provider']) } ['identifier']
+    metadata['identifiers'].find { |i| i['identifier_type'] == provider_ref(metadata['provider']) }['identifier']
   end
 
   # By default, Solr will throw errors for text fields that are longer than 32,766 characters

--- a/app/services/vertex_mapper.rb
+++ b/app/services/vertex_mapper.rb
@@ -54,7 +54,7 @@ class VertexMapper
 
   # Retrieve the identifier used by the provider themselves
   def provider_identifier_field
-    metadata['identifiers'].find { |i| i['identifier_type'] == provider_ref(metadata['provider']) } ['identifier']
+    metadata['identifiers'].find { |i| i['identifier_type'] == provider_ref(metadata['provider']) }['identifier']
   end
 
   def description_field


### PR DESCRIPTION
I closed the dependabot PR that updated rubocop because of the failed linting (the 2 small fixes here) in favor of updating all deps and fixing the linting.