### PR TITLE
Adding openalex in provider preference, handling identifier type

### DIFF
--- a/app/services/dataset_transformer.rb
+++ b/app/services/dataset_transformer.rb
@@ -3,7 +3,7 @@
 # Performs transformation from source metadata to Solr documents for a single dataset
 class DatasetTransformer
   # These providers are ordered by preference for mapping.
-  PROVIDERS = %w[sdr datacite local searchworks dryad redivis zenodo].freeze
+  PROVIDERS = %w[sdr datacite local searchworks dryad redivis zenodo open_alex].freeze
 
   # These fields are merged from the dataset records of other providers in preference order.
   MERGEABLE_FIELDS = [:variables_tsim].freeze

--- a/app/services/solr_mapper.rb
+++ b/app/services/solr_mapper.rb
@@ -144,6 +144,8 @@ class SolrMapper
       'ZenodoId'
     when 'SDR'
       'DRUID'
+    when 'OpenAlex'
+      'OpenAlex'
     else
       "#{provider}Reference"
     end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -79,7 +79,17 @@ datacite:
 
 open_alex:
   ignore:
+    # Missing required fields such as title
     - https://openalex.org/W4240842404
+    - https://openalex.org/W424084240
+    - https://openalex.org/W4242494377
+    - https://openalex.org/W4248206402
+    - https://openalex.org/W4249260174
+    - https://openalex.org/W4255049939
+    - https://openalex.org/W4256093189
+    - https://openalex.org/W4256095229
+
+
 
 searchworks:
   solr_url: https://sul-solr-prod-a.stanford.edu/solr/searchworks-prod

--- a/spec/services/solr_mapper_spec.rb
+++ b/spec/services/solr_mapper_spec.rb
@@ -158,6 +158,19 @@ RSpec.describe SolrMapper do
         expect(solr_mapper.provider_identifier_field).to eq('druid:123ab456')
       end
     end
+
+    context 'with OpenAlex as provider' do
+      let(:metadata) do
+        {
+          provider: 'OpenAlex',
+          identifiers: [{ identifier: 'https://openalex.org/W4240842401', identifier_type: 'OpenAlex' }]
+        }
+      end
+
+      it 'retrieves the SDR DRUID' do
+        expect(solr_mapper.provider_identifier_field).to eq('https://openalex.org/W4240842401')
+      end
+    end
   end
 
   describe '#descriptions_field' do


### PR DESCRIPTION
What this pull request does:
- OpenAlex transformation validation revealed additional datasets that were not conforming to the schema e.g. missing titles.  These have been added to the ignore list along with a comment.
- OpenAlex needed to be added to the list specifying order of preference
- Solr mapping needed to handle the identifier type "OpenAlex"