### PR TITLE
Handle SDR mapping errors after refactoring

### DIFF
--- a/app/services/dataworks_mappers/sdr.rb
+++ b/app/services/dataworks_mappers/sdr.rb
@@ -136,12 +136,12 @@ module DataworksMappers
     # Related items are used for things that may not have an identifier, often
     # user-provided links that only have a title and URL.
     def related_items
-      related_resources.map { |r| RelatedItemMapper.new(r).call }.compact
+      related_resources.map { |r| RelatedItemMapper.new(r).call }.compact_blank
     end
 
     # Related resources with an identifier go here
     def related_identifiers
-      related_resources.map { |r| RelatedItemMapper.new(r).as_related_identifier }.compact
+      related_resources.map { |r| RelatedItemMapper.new(r).as_related_identifier }.compact_blank
     end
 
     # Sizes could be anything, but in example data were rarely populated, and we
@@ -253,14 +253,16 @@ module DataworksMappers
           titles:,
           relation_type:,
           related_item_identifier: {
-            related_item_identifier: identifier.value || url,
-            related_item_identifier_type: identifier.type || ('URL' if url)
-          }
+            related_item_identifier: identifier&.value || url,
+            related_item_identifier_type: identifier&.type || ('URL' if url)
+          }.compact_blank
         }.compact_blank
       end
 
       # RelatedIdentifier form; must have an ID
       def as_related_identifier
+        return nil if identifier.blank?
+
         {
           relation_type:,
           related_identifier: identifier.value,
@@ -281,12 +283,14 @@ module DataworksMappers
         IdentifierMapper.new(id) if id.present?
       end
 
+      # Related resources may have either a purl or more information at the access URL in the
+      # case where no identifiers are present
       def url
-        resource.dig('access', 'url', 0)
+        resource['purl'] || resource.dig('access', 'url', 0, 'value')
       end
 
       def relation_type
-        RELATION_TYPES.fetch(resource['type'], 'Other')
+        RELATION_TYPES.fetch(resource['type'], nil)
       end
     end
 

--- a/spec/fixtures/sources/sdr.json
+++ b/spec/fixtures/sources/sdr.json
@@ -1311,7 +1311,68 @@
         "subject": [],
         "purl": "https://purl.stanford.edu/nk828sc2920",
         "relatedResource": []
-      }
+      },
+      {
+        "title": [
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "FLPedBrain",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          }
+        ],
+        "contributor": [],
+        "event": [],
+        "form": [],
+        "language": [],
+        "note": [],
+        "identifier": [],
+        "subject": [],
+        "access": {
+          "url": [
+            {
+              "structuredValue": [],
+              "parallelValue": [],
+              "groupedValue": [],
+              "value": "https://github.com/edhlee/FLPedBrain",
+              "identifier": [],
+              "note": [],
+              "appliesTo": []
+            }
+          ],
+          "physicalLocation": [],
+          "digitalLocation": [],
+          "accessContact": [],
+          "digitalRepository": [],
+          "note": []
+        },
+        "relatedResource": []
+      },
+      {
+        "title": [
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "FLPedBrain with PURL",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          }
+        ],
+        "contributor": [],
+        "event": [],
+        "form": [],
+        "language": [],
+        "note": [],
+        "identifier": [],
+        "subject": [],
+        "purl": "https://purl.stanford.edu/zx935qw7203",
+        "relatedResource": []
+      }        
     ],
     "marcEncodedData": [],
     "adminMetadata": {

--- a/spec/services/dataworks_mappers/sdr_spec.rb
+++ b/spec/services/dataworks_mappers/sdr_spec.rb
@@ -305,6 +305,134 @@ RSpec.describe DataworksMappers::Sdr do
     )
   end
 
+  # rubocop:disable Layout/LineLength
+  # Related items may not have identifiers but may have URLs
+  it 'maps the related items' do
+    expect(metadata[:related_items]).to eq(
+      [
+        {
+          related_item_identifier: {
+            related_item_identifier: '10.25740/sb4q-wj06',
+            related_item_identifier_type: 'DOI'
+          },
+          relation_type: 'IsPreviousVersionOf',
+          titles: [
+            {
+              title: "2011 Machine Learning Data Set for NASA's Solar Dynamics Observatory - Atmospheric Imaging Assembly"
+            }
+          ]
+        },
+        {
+          related_item_identifier: {
+            related_item_identifier: '10.25740/1vyz-b592',
+            related_item_identifier_type: 'DOI'
+          },
+          relation_type: 'IsPreviousVersionOf',
+          titles: [
+            {
+              title: "2012 Machine Learning Data Set for NASA's Solar Dynamics Observatory - Atmospheric Imaging Assembly"
+            }
+          ]
+        },
+        {
+          related_item_identifier: {
+            related_item_identifier: '10.25740/2zme-3q44',
+            related_item_identifier_type: 'DOI'
+          },
+          relation_type: 'IsPreviousVersionOf',
+          titles: [
+            {
+              title: "2013 Machine Learning Data Set for NASA's Solar Dynamics Observatory - Atmospheric Imaging Assembly"
+            }
+          ]
+        },
+        {
+          related_item_identifier: {
+            related_item_identifier: '10.25740/3jhw-x180',
+            related_item_identifier_type: 'DOI'
+          },
+          relation_type: 'IsPreviousVersionOf',
+          titles: [
+            {
+              title: "2014 Machine Learning Data Set for NASA's Solar Dynamics Observatory - Atmospheric Imaging Assembly"
+            }
+          ]
+        },
+        {
+          related_item_identifier: {
+            related_item_identifier: '10.25740/0fbp-re41',
+            related_item_identifier_type: 'DOI'
+          },
+          relation_type: 'IsPreviousVersionOf',
+          titles: [
+            {
+              title: "2015 Machine Learning Data Set for NASA's Solar Dynamics Observatory - Atmospheric Imaging Assembly"
+            }
+          ]
+        },
+        {
+          related_item_identifier: {
+            related_item_identifier: '10.25740/64cr-bc95',
+            related_item_identifier_type: 'DOI'
+          },
+          relation_type: 'IsPreviousVersionOf',
+          titles: [
+            {
+              title: "2016 Machine Learning Data Set for NASA's Solar Dynamics Observatory - Atmospheric Imaging Assembly"
+            }
+          ]
+        },
+        {
+          related_item_identifier: {
+            related_item_identifier: '10.25740/c8bw-ar96',
+            related_item_identifier_type: 'DOI'
+          },
+          relation_type: 'IsPreviousVersionOf',
+          titles: [
+            {
+              title: "2017 Machine Learning Data Set for NASA's Solar Dynamics Observatory - Atmospheric Imaging Assembly"
+            }
+          ]
+        },
+        {
+          related_item_identifier: {
+            related_item_identifier: '10.25740/pknx-5s37',
+            related_item_identifier_type: 'DOI'
+          },
+          relation_type: 'IsPreviousVersionOf',
+          titles: [
+            {
+              title: "2018 Machine Learning Data Set for NASA's Solar Dynamics Observatory - Atmospheric Imaging Assembly"
+            }
+          ]
+        },
+        {
+          related_item_identifier: {
+            related_item_identifier: 'https://github.com/edhlee/FLPedBrain',
+            related_item_identifier_type: 'URL'
+          },
+          titles: [
+            {
+              title: 'FLPedBrain'
+            }
+          ]
+        },
+        {
+          related_item_identifier: {
+            related_item_identifier: 'https://purl.stanford.edu/zx935qw7203',
+            related_item_identifier_type: 'URL'
+          },
+          titles: [
+            {
+              title: 'FLPedBrain with PURL'
+            }
+          ]
+        }
+      ]
+    )
+  end
+  # rubocop:enable Layout/LineLength
+
   it 'maps the access' do
     expect(metadata[:access]).to eq('Public')
   end


### PR DESCRIPTION
Closes #251 

What this PR does:

- Address situations where specific properties are missing for related items and related identifiers. If a property is required, that element should not be mapped.
- Address nested hash nils/empty values
- Add testing for related items 
- Correct the value to look for within the access struct for a URL for related resource
- Add option to also look at the PURL property for related resource
- Correct the relation type value to be 'nil' instead of Other (i.e this will not map at all) since 'Other' is not included in our schema as a valid relation type