### PR TITLE
Turn off ruby updates via Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,5 @@
 version: 2
 updates:
-- package-ecosystem: bundler
-  directory: "/"
-  schedule:
-    interval: daily
-  open-pull-requests-limit: 10
 - package-ecosystem: github-actions
   directory: "/"
   schedule:


### PR DESCRIPTION
We are using the conventional Jenkins workflow for these updates
now, so dependabot is just duplicating work.

This keeps dependabot updates for changes to github actions
packages, since Jenkins doesn't handle those.
