### PR TITLE
Retry harvesting on 500 and 503 server errors

### DIFF
--- a/app/services/clients/base.rb
+++ b/app/services/clients/base.rb
@@ -42,7 +42,7 @@ module Clients
         max: 10,
         interval: 5.0,
         backoff_factor: 2,
-        retry_statuses: [429, 502]
+        retry_statuses: [429, 500, 502, 503]
       }
     end
   end


### PR DESCRIPTION
We currently use an automated retry with exponential backoff when
API servers respond with certain errors codes (429 and 502).

Some errors (e.g.
https://app.honeybadger.io/projects/131491/faults/121882510) were
caused by other 5XX codes, which might be resolved if we retried them.

This PR adds retries for 500 (generic server error) and 503 (service
unavailable) codes to try to address that.

Ref #389
