### PR TITLE
Add only unique formats from DataCite records

### DIFF
--- a/app/services/dataworks_mappers/datacite.rb
+++ b/app/services/dataworks_mappers/datacite.rb
@@ -18,7 +18,7 @@ module DataworksMappers
         identifiers:,
         related_identifiers:,
         sizes: attrs[:sizes],
-        formats: attrs[:formats],
+        formats: attrs[:formats]&.uniq,
         rights_list:,
         funding_references:,
         url: attrs[:url],

--- a/spec/fixtures/sources/datacite.json
+++ b/spec/fixtures/sources/datacite.json
@@ -824,7 +824,9 @@
       ],
       "formats": [
         "application/xml",
-        "text/plain"
+        "text/plain",
+        "text/csv",
+        "text/csv"
       ],
       "version": "1",
       "rightsList": [

--- a/spec/services/dataworks_mappers/datacite_spec.rb
+++ b/spec/services/dataworks_mappers/datacite_spec.rb
@@ -470,7 +470,8 @@ RSpec.describe DataworksMappers::Datacite do
         ],
         formats: [
           'application/xml',
-          'text/plain'
+          'text/plain',
+          'text/csv'
         ],
         rights_list: [
           {


### PR DESCRIPTION
This handles some pathological records that list the format of
every file, for hundreds of files. Repeating the info isn't useful.
