### PR TITLE
Sum byte sizes and display as human readable strings

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,4 +1,30 @@
 # frozen_string_literal: true
 
 module ApplicationHelper
+  BYTES_REGEX = /^([\d.]+)\s*(bytes|kilobytes|megabytes|gigabytes|terabytes|b|kb|mb|gb|tb)?$/i
+
+  # Given a string like "5 MB" or "1.2 GB", return the number of bytes as an integer
+  # rubocop:disable Metrics/CyclomaticComplexity
+  def number_from_human_size(size)
+    return unless size.is_a?(String)
+
+    match = size.match(BYTES_REGEX)
+    return unless match
+
+    number = match[1].to_f
+    unit = match[2]&.downcase
+
+    multiplier = case unit
+                 when 'kilobytes', 'kb' then 1024
+                 when 'megabytes', 'mb' then 1024**2
+                 when 'gigabytes', 'gb' then 1024**3
+                 when 'terabytes', 'tb' then 1024**4
+                 else 1
+                 end
+
+    (number * multiplier).to_i
+  rescue StandardError
+    nil
+  end
+  # rubocop:enable Metrics/CyclomaticComplexity
 end

--- a/app/services/dataworks_mappers/datacite.rb
+++ b/app/services/dataworks_mappers/datacite.rb
@@ -3,6 +3,8 @@
 module DataworksMappers
   # Map from Datacite metadata to Dataworks metadata
   class Datacite < Base # rubocop:disable Metrics/ClassLength
+    include ApplicationHelper
+
     def perform_map # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
       {
         creators: people_or_organizations_for(attrs[:creators]),
@@ -17,7 +19,7 @@ module DataworksMappers
         version: attrs[:version],
         identifiers:,
         related_identifiers:,
-        sizes: attrs[:sizes],
+        sizes:,
         formats: attrs[:formats]&.uniq,
         rights_list:,
         funding_references:,
@@ -151,6 +153,21 @@ module DataworksMappers
           related_identifier_type: related_identifier[:relatedIdentifierType]
         }.compact
       end
+    end
+
+    # Some records return sizes for every individual file, which isn't useful.
+    # We try to sum up the file sizes and return a single human-readable size.
+    def sizes
+      return if attrs[:sizes].blank?
+
+      # Get all of the sizes that look like bytes (e.g. "5 MB" or just "3492")
+      byte_sizes, sizes = attrs[:sizes]&.partition { |size| size.match?(BYTES_REGEX) }
+      return sizes.uniq if byte_sizes.blank?
+
+      # Sum up the byte sizes and convert to a human-readable format
+      total_size = byte_sizes.map(&method(:number_from_human_size)).sum
+      sizes.push ActiveSupport::NumberHelper.number_to_human_size(total_size) if total_size.positive?
+      sizes.uniq
     end
   end
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ApplicationHelper do
+  describe '#number_from_human_size' do
+    it 'converts human-readable sizes to bytes' do
+      expect(helper.number_from_human_size('5 MB')).to eq(5 * 1024 * 1024)
+      expect(helper.number_from_human_size('1.5 GB')).to eq((1.5 * (1024**3)).to_i)
+      expect(helper.number_from_human_size('100 bytes')).to eq(100)
+      expect(helper.number_from_human_size('2 TB')).to eq(2 * (1024**4))
+      expect(helper.number_from_human_size('500 kb')).to eq(500 * 1024)
+      expect(helper.number_from_human_size('250 b')).to eq(250)
+      expect(helper.number_from_human_size('1')).to eq(1)
+    end
+
+    it 'handles edge cases and invalid inputs' do
+      expect(helper.number_from_human_size('invalid')).to be_nil
+      expect(helper.number_from_human_size('123 unknown')).to be_nil
+      expect(helper.number_from_human_size(nil)).to be_nil
+      expect(helper.number_from_human_size(123)).to be_nil
+      expect(helper.number_from_human_size('')).to be_nil
+    end
+
+    it 'is case insensitive for units' do
+      expect(helper.number_from_human_size('5 mb')).to eq(5 * 1024 * 1024)
+      expect(helper.number_from_human_size('1.5 Gb')).to eq((1.5 * (1024**3)).to_i)
+      expect(helper.number_from_human_size('100 BYTES')).to eq(100)
+    end
+  end
+end

--- a/spec/services/dataworks_mappers/datacite_spec.rb
+++ b/spec/services/dataworks_mappers/datacite_spec.rb
@@ -465,8 +465,8 @@ RSpec.describe DataworksMappers::Datacite do
         provider: 'DataCite',
         access: 'Public',
         sizes: [
-          '1 MB',
-          '90 pages'
+          '90 pages',
+          '1 MB'
         ],
         formats: [
           'application/xml',
@@ -716,5 +716,15 @@ RSpec.describe DataworksMappers::Datacite do
         ]
       }
     )
+  end
+
+  context 'with a variety of size info' do
+    let(:sizes) { ['10 MB', '2048 bytes', '5.5 GB', '100 kilobytes', '90 pages'] }
+
+    before { source['data']['attributes']['sizes'] = sizes }
+
+    it 'parses and sums sizes correctly' do
+      expect(metadata[:sizes]).to eq(['90 pages', '5.51 GB'])
+    end
   end
 end


### PR DESCRIPTION
This handles some pathological cases in DataCite records that
listed sizes in bytes for every file, which isn't useful.

Instead, we find all of the sizes that give byte information and
sum them into a human-readable total size, which mimics the way
we display this information for SDR records.
