### PR TITLE
Remove unused config

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -108,10 +108,6 @@ purl_fetcher:
 purl:
   url: https://purl.stanford.edu
 
-dor_services:
-  url: https://dor-services-prod-lb.stanford.edu
-  token: ~
-
 honeybadger:
   datacite_extract_job_stanford_university_checkin: ~
   datacite_extract_job_sul_checkin: ~


### PR DESCRIPTION
This is from back when we were using dor-services-app to fetch
Cocina for objects, which we are no longer doing.
