### PR TITLE
adding status code for retry

### DIFF
--- a/app/services/clients/base.rb
+++ b/app/services/clients/base.rb
@@ -50,7 +50,7 @@ module Clients
         max: 10,
         interval: 5.0,
         backoff_factor: 2,
-        retry_statuses: [429, 500, 502, 503]
+        retry_statuses: [429, 500, 502, 503, 504]
       }
     end
   end


### PR DESCRIPTION
Enables Zenodo harvesting to not throw errors and stop immediately on 504 errors