### PR TITLE
add stanford dataset flag to index

### DIFF
--- a/app/services/solr_mapper.rb
+++ b/app/services/solr_mapper.rb
@@ -61,9 +61,9 @@ class SolrMapper
       courses_sim: courses,
       geo_place_ssim: geo_locations_field,
       provider_identifier_map_struct_ss: provider_identifiers_map.presence&.to_json,
-      stanford_project_ssi: metadata['stanford_project'],
-      stanford_contributor_ssi: stanford_contributor?,
-      stanford_dataset_ssi: metadata['stanford_project'] || stanford_contributor?
+      stanford_project_bsi: metadata['stanford_project'],
+      stanford_contributor_bsi: stanford_contributor?,
+      stanford_dataset_bsi: metadata['stanford_project'] || stanford_contributor?
     }.merge(title_fields).merge(struct_fields).compact_blank
   end
   # rubocop:enable Metrics/AbcSize, Metrics/MethodLength

--- a/spec/services/solr_mapper_spec.rb
+++ b/spec/services/solr_mapper_spec.rb
@@ -65,9 +65,9 @@ RSpec.describe SolrMapper do
             courses_sim: ['CS246'],
             provider_identifier_map_struct_ss: '{"DataCite":"10.1234/5678","Redivis":"redivis-123"}',
             geo_place_ssim: ['Vancouver, British Columbia, Canada', 'Victoria, British Columbia, Canada'],
-            stanford_project_ssi: true,
-            stanford_contributor_ssi: true,
-            stanford_dataset_ssi: true,
+            stanford_project_bsi: true,
+            stanford_contributor_bsi: true,
+            stanford_dataset_bsi: true,
             access_contact_struct_ss: '[{"name":"Contact Person","email":"contact@contact.com"}]'
           }
         )
@@ -438,7 +438,7 @@ RSpec.describe SolrMapper do
 
       it 'identifies dataset as a Stanford dataset' do
         expect(solr_mapper.call).to include(
-          stanford_dataset_ssi: true
+          stanford_dataset_bsi: true
         )
       end
     end
@@ -467,7 +467,7 @@ RSpec.describe SolrMapper do
 
       it 'identifies dataset as a Stanford dataset' do
         expect(solr_mapper.call).to include(
-          stanford_dataset_ssi: true
+          stanford_dataset_bsi: true
         )
       end
     end


### PR DESCRIPTION
Closes #431 

Adds stanford dataset flag to index for each dataset which is either stanford project or stanford contributor or both.
Makes all the stanford flag fields into boolean