### PR TITLE
Adjust some configs to make them easier to override via puppet

### DIFF
--- a/app/services/cocina_service.rb
+++ b/app/services/cocina_service.rb
@@ -5,9 +5,9 @@ class CocinaService
   attr_reader :purl_url
 
   # Initialize the service
-  # @param purl_url [String] Base URL for PURL from which to fetch Cocina
-  def initialize(purl_url: Settings.purl.url)
-    @purl_url = purl_url
+  # @param purl_hostname [String] Base hostname for PURL to fetch Cocina
+  def initialize(purl_hostname: Settings.purl.hostname)
+    @purl_url = "https://#{purl_hostname}"
   end
 
   # Fetch the Cocina record from PURL for a given item by druid

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -210,7 +210,7 @@ purl_fetcher:
 # Determines the environment that cocina metadata will be fetched from; for
 # stage indexing it should be set to staging PURL
 purl:
-  url: https://sul-purl-stage.stanford.edu
+  hostname: sul-purl-stage.stanford.edu
 
 # Should be purl_fetcher_stage or purl_fetcher_prod; determines which queue
 # of SDR item updates we are 'listening' to

--- a/lib/sdr_events.rb
+++ b/lib/sdr_events.rb
@@ -8,10 +8,10 @@ require 'socket'
 class SdrEvents
   class << self
     def configure(
-      hostname: ENV.fetch('SDR_EVENTS_MQ_HOSTNAME', ::Settings.sdr_events.mq.hostname),
-      vhost: ENV.fetch('SDR_EVENTS_MQ_VHOST', ::Settings.sdr_events.mq.vhost),
-      username: ENV.fetch('SDR_EVENTS_MQ_USERNAME', ::Settings.sdr_events.mq.username),
-      password: ENV.fetch('SDR_EVENTS_MQ_PASSWORD', ::Settings.sdr_events.mq.password)
+      hostname: Settings.sdr_events.mq.hostname,
+      vhost: Settings.sdr_events.mq.vhost,
+      username: Settings.sdr_events.mq.username,
+      password: Settings.sdr_events.mq.password
     )
       Dor::Event::Client.configure(hostname:, vhost:, username:, password:)
     end


### PR DESCRIPTION
The puppet profile for racecar automatically creates and expects
SETTINGS__PURL__HOSTNAME, so use that naming instead of 'url'.

Also, remove the envvars for SDR events config, since you can
already set or ovverride them using RailsConfig env var naming,
e.g. SETTINGS__SDR_EVENTS__MQ__PASSWORD.

These are needed because the envvars that get set by puppet will
overwrite settings in the file or from shared_configs, so we should
play by puppet's rules.
