### PR TITLE
Store records harvested via Kafka in the database

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -38,6 +38,9 @@ RSpec/MultipleExpectations:
 RSpec/MultipleMemoizedHelpers:
   Enabled: false
 
+RSpec/NestedGroups:
+  Enabled: false
+
 Style/Documentation:
   Exclude:
     - '**/application*'

--- a/app/consumers/sdr_consumer.rb
+++ b/app/consumers/sdr_consumer.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
-# Harvest and index datasets published from SDR
+# Incrementally harvest, store, and index datasets published from SDR
+# rubocop:disable Metrics/ClassLength
 class SdrConsumer < Racecar::Consumer
   subscribes_to Settings.indexer_topic
   self.group_id = Settings.indexer_group
@@ -51,7 +52,7 @@ class SdrConsumer < Racecar::Consumer
     return process_skip if should_skip?
 
     process_update
-  rescue StandardError => e
+  rescue DataworksMappers::MappingError => e
     context = { druid: @druid, record: cocina_record&.cocina_doc }
     Honeybadger.notify(e, context: context)
     SdrEvents.report_indexing_errored(@druid, target: 'Dataworks', message: e.message, context: context)
@@ -122,23 +123,40 @@ class SdrConsumer < Racecar::Consumer
     nil
   end
 
+  # Reference to the single persistent dataset record set for SDR
+  def dataset_record_set
+    @dataset_record_set ||= DatasetRecordSet.find_or_create_by!(provider: 'sdr', complete: true)
+  end
+
+  # Create or update the DatasetRecord for this item
+  def update_dataset_record
+    dataset_record = DatasetRecord.find_or_initialize_by(provider: 'sdr', dataset_id: @druid)
+    dataset_record.dataset_record_set_ids = [dataset_record_set.id]
+    dataset_record.source = cocina_record.cocina_doc
+    dataset_record.modified_token = cocina_record.modified_time
+    dataset_record.save!
+  end
+
   # Notify SDR that we didn't take any action for some reason
   def process_skip
     SdrEvents.report_indexing_skipped(@druid, target: 'Dataworks', message: skip_reason)
     Rails.logger.info { "SDR indexer skipped druid:#{@druid}; #{skip_reason}" }
   end
 
-  # Remove item from the index and notify SDR
+  # Remove item from the database and index and notify SDR
   def process_delete
+    DatasetRecord.destroy_by(provider: 'sdr', dataset_id: @druid)
     @solr_service.delete(id: @druid)
     Rails.logger.info { "SDR indexer deleted druid:#{@druid}" }
     SdrEvents.report_indexing_deleted(@druid, target: 'Dataworks')
   end
 
-  # Add/update item in the index and notify SDR
+  # Add/update item in the database and index and notify SDR
   def process_update
+    update_dataset_record
     @solr_service.add(solr_doc: SdrConsumer.map_record(cocina_record))
     Rails.logger.info { "SDR indexer updated druid:#{@druid}" }
     SdrEvents.report_indexing_success(@druid, target: 'Dataworks')
   end
 end
+# rubocop:enable Metrics/ClassLength

--- a/app/services/extractors/base.rb
+++ b/app/services/extractors/base.rb
@@ -15,14 +15,16 @@ module Extractors
       @extra_dataset_ids = extra_dataset_ids
     end
 
-    # @return [DatasetRecordSet] the set of dataset records created
+    # Perform extraction and return the populated DatasetRecordSet
+    # @return [DatasetRecordSet]
     def call
-      dataset_record_set = DatasetRecordSet.create!(provider:, extractor: self.class.name, list_args: list_args.to_json)
+      dataset_record_set = create_dataset_record_set
 
       results.each do |result|
         dataset_record = find_or_create_dataset_record(result:)
         dataset_record_set.dataset_records << dataset_record
       end
+
       dataset_record_set.update!(complete: true)
       dataset_record_set
     end
@@ -30,6 +32,12 @@ module Extractors
     private
 
     attr_reader :client, :provider, :list_args, :extract_sleep, :extra_dataset_ids
+
+    # Create a new DatasetRecordSet to contain records from this run
+    # @return [DatasetRecordSet]
+    def create_dataset_record_set
+      DatasetRecordSet.create!(provider:, extractor: self.class.name, list_args: list_args.to_json)
+    end
 
     def results
       (extra_dataset_results + client.list(**list_args)).uniq(&:id)

--- a/app/services/extractors/sdr.rb
+++ b/app/services/extractors/sdr.rb
@@ -13,6 +13,12 @@ module Extractors
 
     private
 
+    # For SDR, we use a single persistent set rather than creating a new one
+    # each harvest. This supports both incremental and on-demand harvesting
+    def create_dataset_record_set
+      DatasetRecordSet.find_or_create_by!(provider: provider, complete: true)
+    end
+
     # Only index what was specified in extra_dataset_ids; everything else
     # comes in through the SdrConsumer
     def results

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -9,3 +9,6 @@
 #   ["Action", "Comedy", "Drama", "Horror"].each do |genre_name|
 #     MovieGenre.find_or_create_by!(name: genre_name)
 #   end
+
+# Ensure the existence of the single persistent SDR DatasetRecordSet
+DatasetRecordSet.find_or_create_by!(provider: 'sdr', complete: true)

--- a/spec/consumers/sdr_consumer_spec.rb
+++ b/spec/consumers/sdr_consumer_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe SdrConsumer do
   let(:message_contents) { { druid: 'druid:cz537wr8540', true_targets: ['Dataworks'] } }
   let(:solr_service) { instance_double(SolrService, delete: true, add: true) }
   let(:cocina_service) { instance_double(CocinaService, cocina_record: record) }
+  let(:sdr_set) { DatasetRecordSet.find_or_create_by!(provider: 'sdr', complete: true) }
 
   before do
     allow(Settings).to receive_messages(
@@ -36,10 +37,39 @@ RSpec.describe SdrConsumer do
   end
 
   describe '#process' do
+    context 'when the item is in the database already' do
+      before do
+        DatasetRecord.create!(
+          provider: 'sdr',
+          dataset_id: 'cz537wr8540',
+          source: {},
+          dataset_record_set_ids: [sdr_set.id]
+        )
+      end
+
+      it 'updates the item in the database' do
+        consumer.process(message)
+        dataset_record = DatasetRecord.find_by(provider: 'sdr', dataset_id: 'cz537wr8540')
+        expect(dataset_record.source).to eq(cocina)
+      end
+    end
+
+    context 'when the item is not in the database' do
+      it 'creates the item in the database' do
+        consumer.process(message)
+        dataset_record = DatasetRecord.find_by(provider: 'sdr', dataset_id: 'cz537wr8540')
+        expect(dataset_record.source).to eq(cocina)
+      end
+    end
+
     it 'sends the mapped item to Solr' do
       solr_doc = described_class.map_record(record)
       consumer.process(message)
       expect(solr_service).to have_received(:add).with(solr_doc: solr_doc)
+    end
+
+    it 'notifies SDR of successful indexing' do
+      consumer.process(message)
       expect(SdrEvents).to have_received(:report_indexing_success).with('cz537wr8540', target: 'Dataworks')
     end
 
@@ -47,10 +77,14 @@ RSpec.describe SdrConsumer do
       let(:targets) { ['PURL Sitemap', 'Searchworks'] }
       let(:message_contents) { { druid: 'druid:cz537wr8540', true_targets: ['purl sitemap', 'SearchWorks'] } }
 
-      it 'sends the mapped item to Solr and notifies SDR' do
+      it 'sends the mapped item to Solr' do
         solr_doc = described_class.map_record(record)
         consumer.process(message)
         expect(solr_service).to have_received(:add).with(solr_doc: solr_doc)
+      end
+
+      it 'notifies SDR of successful indexing' do
+        consumer.process(message)
         expect(SdrEvents).to have_received(:report_indexing_success).with('cz537wr8540', target: 'Dataworks')
       end
     end
@@ -68,9 +102,35 @@ RSpec.describe SdrConsumer do
     context 'when the kafka message had no content' do
       let(:message_contents) { nil }
 
-      it 'executes a delete and notifies SDR' do
+      context 'when the item is in the database already' do
+        before do
+          DatasetRecord.create!(
+            provider: 'sdr',
+            dataset_id: 'cz537wr8540',
+            source: {},
+            dataset_record_set_ids: [sdr_set.id]
+          )
+        end
+
+        it 'removes the item from the database' do
+          consumer.process(message)
+          expect(DatasetRecord.find_by(provider: 'sdr', dataset_id: 'cz537wr8540')).to be_nil
+        end
+      end
+
+      context 'when the item is not in the database' do
+        it 'does not raise an error' do
+          expect { consumer.process(message) }.not_to raise_error
+        end
+      end
+
+      it 'removes the item from the index' do
         consumer.process(message)
         expect(solr_service).to have_received(:delete).with(id: 'cz537wr8540')
+      end
+
+      it 'notifies SDR' do
+        consumer.process(message)
         expect(SdrEvents).to have_received(:report_indexing_deleted).with('cz537wr8540', target: 'Dataworks')
       end
     end
@@ -83,9 +143,35 @@ RSpec.describe SdrConsumer do
         }
       end
 
-      it 'executes a delete and notifies SDR' do
+      context 'when the item is in the database already' do
+        before do
+          DatasetRecord.create!(
+            provider: 'sdr',
+            dataset_id: 'cz537wr8540',
+            source: {},
+            dataset_record_set_ids: [sdr_set.id]
+          )
+        end
+
+        it 'removes the item from the database' do
+          consumer.process(message)
+          expect(DatasetRecord.find_by(provider: 'sdr', dataset_id: 'cz537wr8540')).to be_nil
+        end
+      end
+
+      context 'when the item is not in the database' do
+        it 'does not raise an error' do
+          expect { consumer.process(message) }.not_to raise_error
+        end
+      end
+
+      it 'removes the item from the index' do
         consumer.process(message)
         expect(solr_service).to have_received(:delete).with(id: 'cz537wr8540')
+      end
+
+      it 'notifies SDR' do
+        consumer.process(message)
         expect(SdrEvents).to have_received(:report_indexing_deleted).with('cz537wr8540', target: 'Dataworks')
       end
     end
@@ -95,9 +181,13 @@ RSpec.describe SdrConsumer do
         allow(cocina_service).to receive(:cocina_record).and_raise(Faraday::ResourceNotFound)
       end
 
-      it 'skips indexing and notifies SDR' do
+      it 'skips indexing' do
         consumer.process(message)
         expect(solr_service).not_to have_received(:add)
+      end
+
+      it 'notifies SDR' do
+        consumer.process(message)
         expect(SdrEvents).to have_received(:report_indexing_skipped).with(
           'cz537wr8540',
           target: 'Dataworks',
@@ -108,13 +198,17 @@ RSpec.describe SdrConsumer do
 
     context 'when the item is not a self-deposited dataset' do
       before do
-        # Remove the self-deposit resource type
+        # Remove the self-deposit resource type from the item
         cocina['description']['form'][0] = {}
       end
 
-      it 'skips indexing and notifies SDR' do
+      it 'skips indexing' do
         consumer.process(message)
         expect(solr_service).not_to have_received(:add)
+      end
+
+      it 'notifies SDR' do
+        consumer.process(message)
         expect(SdrEvents).to have_received(:report_indexing_skipped).with(
           'cz537wr8540',
           target: 'Dataworks',
@@ -130,9 +224,13 @@ RSpec.describe SdrConsumer do
         cocina['access']['download'] = 'none'
       end
 
-      it 'skips indexing and notifies SDR' do
+      it 'skips indexing' do
         consumer.process(message)
         expect(solr_service).not_to have_received(:add)
+      end
+
+      it 'notifies SDR' do
+        consumer.process(message)
         expect(SdrEvents).to have_received(:report_indexing_skipped).with(
           'cz537wr8540',
           target: 'Dataworks',


### PR DESCRIPTION
This converts the SDR DatasetRecordSet into a single, persistent
set that is not deleted when the TransformLoadJob runs. Instead,
the SDR harvester updates records in that set as they are published,
in addition to indexing them immediately.

This prevents SDR records from getting deleted during Transform runs
since they are always "the most recent set".
