### PR TITLE
indexing late Friday

### DIFF
--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -58,4 +58,4 @@ production:
     schedule: every sunday
   tl:
     class: TransformLoadJob
-    schedule: every thursday
+    schedule: every saturday


### PR DESCRIPTION
Currently, the indexing runs late on Wednesday/early on Thursday (it says Thursday in the schedule).  Changing this to Saturday will make indexing run after work week hours, which might be good in general for us for a weekly schedule since the index will be stable unless we choose to update it.