### PR TITLE
adding affiliation name using string keys to support  pluck

### DIFF
--- a/app/services/dataset_transformer.rb
+++ b/app/services/dataset_transformer.rb
@@ -55,7 +55,7 @@ class DatasetTransformer
     check_mapping_success(dataset_record:)
 
     # Add enhancements
-    metadata = enhance_metadata(mapped_record: metadata)
+    metadata = enhance_metadata(mapped_record: metadata).with_indifferent_access
 
     # Call the Solr mapper (or vertex related transformation)
     mapper_class.call(metadata:, doi: dataset_record.doi, id: dataset_record.external_dataset_id, load_id:,

--- a/app/services/metadata_enhancer.rb
+++ b/app/services/metadata_enhancer.rb
@@ -50,10 +50,10 @@ class MetadataEnhancer
   # If Stanford University does not exist as an affiliation, add that block
   def add_departments(contributor:, departments:)
     affiliation_info = {
-      name: 'Stanford University',
-      affiliation_identifier: 'https://ror.org/00f54p054', affiliation_identifier_scheme: 'ROR',
-      affiliation_department_name: departments
-    }
+      'name' => 'Stanford University',
+      'affiliation_identifier' => 'https://ror.org/00f54p054', 'affiliation_identifier_scheme' => 'ROR',
+      'affiliation_department_name' => departments
+    }.with_indifferent_access
 
     if contributor[:affiliation].blank?
       contributor[:affiliation] = [affiliation_info]

--- a/spec/services/metadata_enhancer_spec.rb
+++ b/spec/services/metadata_enhancer_spec.rb
@@ -37,4 +37,34 @@ RSpec.describe MetadataEnhancer do
                                                                   ]))
     end
   end
+
+  context 'when provider metadata does not have Stanford University in affiliation' do
+    let(:mapped_record) do
+      {
+        titles: [{ title: 'My title' }],
+        publication_year: '2023',
+        identifiers: [{ identifier: '10.1234/5678', identifier_type: 'DOI' }],
+        url: 'https://example.com/my-dataset',
+        access: 'Public',
+        provider: 'DataCite',
+        creators: [
+          {
+            name: 'Creator',
+            name_identifiers: [
+              {
+                name_identifier: 'https://orcid.org/0000-0001-2345-6789',
+                name_identifier_scheme: 'ORCID'
+              }
+            ]
+          }
+        ]
+      }
+    end
+    let(:enhanced_record) { described_class.call(mapped_record:) }
+
+    it 'adds Stanford University affiliation block' do
+      creator = enhanced_record[:creators][0]
+      expect(creator['affiliation']).to include(hash_including('name' => 'Stanford University'))
+    end
+  end
 end

--- a/spec/services/solr_mapper_spec.rb
+++ b/spec/services/solr_mapper_spec.rb
@@ -498,12 +498,13 @@ RSpec.describe SolrMapper do
         }
       end
 
-      it 'populates the department field' do
+      it 'populates the department field, struct field, and contributor flag' do
         expect(solr_mapper.call).to include(
           department_ssim: [
             'Test Department 1',
             'Test Department 2'
           ],
+          stanford_contributor_bsi: true,
           creators_struct_ss: '[{"affiliation":[{"name":"Stanford University","affiliation_department_name":["Test Department 1","Test Department 2"]}]}]'
         )
       end


### PR DESCRIPTION
Closes #463 

Before:
When we add information from the Stanford Authors table, and if the Stanford University affiliation block doesn't already exist, we add that info.  Affiliation names are retrieved using pluck('name').  Our original version of adding a new Stanford University affiliation block used the symbol 'name' instead of the string 'name' which was not being picked up by pluck (even after using with_indifferent_access).

What this PR does:
Uses string keys for a newly added affiliation block
Adds 'with_indifferent_access' to the enhanced metadata - just to be safe.
