### PR TITLE
Support SDR related items that are only a title/citation

### DIFF
--- a/app/services/dataworks_mappers/sdr.rb
+++ b/app/services/dataworks_mappers/sdr.rb
@@ -179,9 +179,6 @@ module DataworksMappers
 
     # Convert Cocina titles to DataCite structured data
     class TitleMapper
-      # The main title, plus any additional titles.
-      # Note that this is also called by RelatedResources, which may have no
-      # titles at all, in which case it will return nil.
       def self.call(record)
         [].tap do |titles|
           titles << { title: record.main_title } if record.main_title.present?
@@ -245,8 +242,10 @@ module DataworksMappers
 
       attr_reader :resource
 
+      # RelatedResource#to_s will use titles if present, falling back to
+      # preferred citation or other information as needed
       def titles
-        TitleMapper.call(resource)
+        [{ title: resource.to_s }]
       end
 
       def identifier
@@ -256,7 +255,7 @@ module DataworksMappers
       # Items deposited using H3 may have dataCiteRelationType populated, but
       # if not, we need to convert using the lookup table
       def relation_type
-        resource.cocina_doc['dataCiteRelationType'] || RELATION_TYPES.fetch(resource.type, nil)
+        resource.cocina_doc.dig('description', 'dataCiteRelationType') || RELATION_TYPES.fetch(resource.type, nil)
       end
 
       # Items deposited using H3 may have DataCite resource type populated

--- a/config/dataworks_schema.yml
+++ b/config/dataworks_schema.yml
@@ -419,7 +419,7 @@ components:
             related_item_identifier_type:
               $ref: '#/components/schemas/IdentifierType'
       required:
-        - related_item_identifier
+        - titles
       additionalProperties: false  # DataCite allows many more fields we don't use
     RelatedIdentifier:
       type: object

--- a/spec/services/dataworks_mappers/sdr_spec.rb
+++ b/spec/services/dataworks_mappers/sdr_spec.rb
@@ -446,4 +446,31 @@ RSpec.describe DataworksMappers::Sdr do
       )
     end
   end
+
+  context 'when there are related resources that are citations only' do
+    before do
+      source['description']['relatedResource'] = []
+      source['description']['relatedResource'].push(
+        {
+          'type' => 'preceded by',
+          'dataCiteRelationType' => 'Continues',
+          'note' => [
+            { 'value' => 'Some article related to the dataset' },
+            { 'type' => 'preferred citation' }
+          ]
+        }
+      )
+    end
+
+    it 'uses the citation and the datacite relation type' do
+      expect(metadata[:related_items]).to include(
+        {
+          titles: [
+            { title: 'Some article related to the dataset' }
+          ],
+          relation_type: 'Continues'
+        }
+      )
+    end
+  end
 end


### PR DESCRIPTION
This allows for mapping related items on SDR records that consist
only of a text citation, with no associated link or URI.

Updates the schema so that title (instead of URL) is the minimal
requirement for related items without an ID.

Also fixes a bug where we weren't respecting the datacite relation
type if it had been set via H3.

Fixes #479
