### PR TITLE
adding ability to request openalex records for any given DOIs and add…

### DIFF
--- a/app/services/clients/open_alex.rb
+++ b/app/services/clients/open_alex.rb
@@ -24,11 +24,32 @@ module Clients
       results
     end
 
+    # This is for related works filter query
+    # @param relationship [String] the relationship we wish to filter by, cites or cited_by
+    # @param doi [String] the DOI of the work we wish to query for
+    # @param page_size [Integer] the number of results to return per page (optional, default/max: 200)
+    # @return list of results combined from multiple calls if required
+    # @raise [Clients::Error] if the request fails
+    def query_relationship(relationship:, id:, page_size: 200)
+      @page_size = page_size
+      results, cursor = query_relationship_page(relationship:, id:)
+      while cursor
+        next_results, cursor = query_relationship_page(cursor:, relationship:, id:)
+        results.concat(next_results)
+      end
+      results
+    end
+
     attr_reader :institution_id, :type, :page_size
 
     # @param id [String] the Identifier of the dataset
     def dataset(id:)
       get_json(path: "/works/#{id.delete_prefix('https://openalex.org/')}")
+    end
+
+    # @param doi [String] the DOI of the dataset
+    def dataset_doi(doi:)
+      get_json(path: "/works/https://doi.org/#{doi}")
     end
 
     # Pass API key as a query parameter if provided
@@ -51,6 +72,24 @@ module Clients
       end
       cursor = response_json.dig('meta', 'next_cursor')
       [results, cursor]
+    end
+
+    # Run query and use the cursor-based method to select a particular page
+    def query_relationship_page(relationship:, id:, cursor: '*')
+      response_json = get_json(path: '/works',
+                               params: query_relationship_params(cursor:, relationship:, id:))
+      results = response_json['results']
+      cursor = response_json.dig('meta', 'next_cursor')
+      [results, cursor]
+    end
+
+    def query_relationship_params(cursor:, relationship:, id:)
+      {
+        cursor: cursor,
+        filter: "#{relationship}:#{id},type:!dataset|database|software",
+        'per-page': page_size,
+        select: 'id,doi,ids,type'
+      }
     end
 
     def params(cursor:)

--- a/app/services/dataset_transformer.rb
+++ b/app/services/dataset_transformer.rb
@@ -55,7 +55,7 @@ class DatasetTransformer
     check_mapping_success(dataset_record:)
 
     # Add enhancements
-    metadata = enhance_metadata(mapped_record: metadata).with_indifferent_access
+    metadata = enhance_metadata(mapped_record: metadata, doi: dataset_record.doi).with_indifferent_access
 
     # Call the Solr mapper (or vertex related transformation)
     mapper_class.call(metadata:, doi: dataset_record.doi, id: dataset_record.external_dataset_id, load_id:,
@@ -113,7 +113,7 @@ class DatasetTransformer
 
   # Metadata enhancement one record at a time
   # Parameter is the DataWorks schema record, not Solr record
-  def enhance_metadata(mapped_record:)
-    MetadataEnhancer.call(mapped_record:)
+  def enhance_metadata(mapped_record:, doi:)
+    MetadataEnhancer.call(mapped_record:, doi:)
   end
 end

--- a/app/services/metadata_enhancer.rb
+++ b/app/services/metadata_enhancer.rb
@@ -6,90 +6,24 @@ class MetadataEnhancer
     new(...).call
   end
 
-  def initialize(mapped_record:)
+  def initialize(mapped_record:, doi:)
     @mapped_record = mapped_record.with_indifferent_access
+    @doi = doi
   end
 
   # @return enhanced metadata record for the dataset with additional metadata
   def call
-    add_stanford_authors
+    @mapped_record = enhance_with_stanford_data
+    @mapped_record = enhance_with_openalex
     @mapped_record
   end
 
-  # Match stanford contributors and creators with Stanford authorrsbased on ORCIDs
-  def add_stanford_authors
-    # Do we have any ORCIDs?
-    contributors = Array(@mapped_record[:creators]).concat(Array(@mapped_record[:contributors]))
-    contributors.each do |contributor|
-      # Does it have a name section with an identfier
-      name_identifiers = contributor[:name_identifiers] || []
-      # See if Orcid exists
-      orcid = retrieve_metadata_orcid(name_identifiers:)
-
-      if orcid.present?
-        author = retrieve_stanford_author(orcid:)
-        enhance_author(contributor:, author:) if author.present?
-      end
-    end
+  # Enhance with OpenAlex information
+  def enhance_with_openalex
+    OpenalexEnhancer.new(mapped_record: @mapped_record, doi: @doi).add_metadata
   end
 
-  # Add caps profile id and department names
-  def enhance_author(contributor:, author:)
-    # Add cap profile id to the name identifiers
-    cap_identifier = {
-      'name_identifier' => author.cap_profile_id,
-      'name_identifier_scheme' => 'CAP'
-    }
-
-    # Update creators - if ORCID exists there is already a name identifiers block
-    contributor[:name_identifiers] << cap_identifier
-    add_departments(contributor:, departments: author.departments) if author.departments.present?
-  end
-
-  # Add departments to the affiliation section for creator/contributor metadata
-  # If Stanford University does not exist as an affiliation, add that block
-  def add_departments(contributor:, departments:)
-    affiliation_info = {
-      'name' => 'Stanford University',
-      'affiliation_identifier' => 'https://ror.org/00f54p054', 'affiliation_identifier_scheme' => 'ROR',
-      'affiliation_department_name' => departments
-    }.with_indifferent_access
-
-    if contributor[:affiliation].blank?
-      contributor[:affiliation] = [affiliation_info]
-      return
-    end
-
-    # Is there an existing affiliation block for Stanford?
-    affiliation_blocks = contributor[:affiliation].select do |a|
-      a[:name] == 'Stanford University' || a[:affiliation_identifier] == 'https://ror.org/00f54p054'
-    end
-
-    if affiliation_blocks.empty?
-      contributor[:affiliation] << affiliation_info
-    else
-      affiliation_blocks.first[:affiliation_department_name] = departments
-    end
-  end
-
-  # Retrieve the ORCID, if it exists, from the name identifiers block in the metadata
-  def retrieve_metadata_orcid(name_identifiers:)
-    name_identifiers.each do |name_identifier_info|
-      identifier = name_identifier_info['name_identifier']
-      scheme = name_identifier_info['name_identifier_scheme']
-      return identifier if (scheme.present? && scheme == 'ORCID') || identifier.start_with?('https://orcid.org/')
-    end
-
-    nil
-  end
-
-  # Query the Stanford authors table to retrieve the matching author for an ORCID
-  def retrieve_stanford_author(orcid:)
-    # Use the form of the ORCID that starts with "https://orcid.org"
-    orcid = "https://orcid.org/#{orcid}" unless orcid.start_with?('https://orcid.org/')
-    authors = StanfordAuthor.where(orcid:, active: true)
-    authors.count.positive? ? authors.first : nil
-  rescue StandardError
-    nil
+  def enhance_with_stanford_data
+    StanfordEnhancer.new(mapped_record: @mapped_record).add_stanford_authors
   end
 end

--- a/app/services/openalex_enhancer.rb
+++ b/app/services/openalex_enhancer.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+# Add specific metadata from OpenAlex for a given dataset
+class OpenalexEnhancer
+  def initialize(mapped_record:, doi:)
+    @mapped_record = mapped_record
+    @doi = doi
+    @mapped_record_dois = map_record_related_dois
+    @client = Clients::OpenAlex.new(api_token: Settings.open_alex.api_token)
+    @openalex_record = @client.dataset_doi(doi: @doi) if doi.present?
+  rescue Clients::Error => e
+    # We do not want Honeybadger notifications b/c OpenAlex provides a 404
+    # for any dataset that does not exist
+    Rails.logger.debug { "OpenAlex record retrieval error for #{@doi}, #{e}" }
+  end
+
+  def add_metadata
+    return @mapped_record if @doi.blank? || @openalex_record.blank?
+
+    @id = @openalex_record['id']
+    # Publications this work references. The filter query uses order: works cited_by this work
+    cites = related_publications(relationship: 'cited_by', field: 'referenced_works_count')
+    # Publications that cite this work, or those this work is cited by
+    # The filter query uses the order: works that cite this work
+    cited_by = related_publications(relationship: 'cites', field: 'cited_by_count')
+    all_publications = cites.concat(cited_by)
+
+    if all_publications.size.positive?
+      @mapped_record['related_identifiers'] = [] if @mapped_record['related_identifiers'].blank?
+
+      @mapped_record['related_identifiers'].concat(all_publications)
+    end
+
+    @mapped_record
+  end
+
+  # This returns related publications but leaves out any DOIs that are already present in
+  # the related identifiers list in the metadata record
+  def related_publications(relationship:, field:)
+    # If the count field for this relationship is 0, we will not query for this relationship
+    return [] unless @openalex_record[field].to_i.positive?
+
+    # Query open alex for referenced works that not datasets, databases, software
+    related_works = @client.query_relationship(relationship:, id: @id)
+    related_works.filter_map do |related_work|
+      unless related_work['doi'].present? && @mapped_record_dois.include?(related_work['doi'].delete_prefix('https://doi.org/'))
+        model_related_work(relationship:,
+                           related_work:)
+      end
+    end
+  end
+
+  def model_related_work(relationship:, related_work:)
+    {
+      'related_identifier' => related_work['id'].delete_prefix('https://openalex.org/'),
+      'relation_type' => relationship_label(relationship:),
+      'related_identifier_type' => 'OpenAlex'
+    }
+  end
+
+  # The filter query is in the opposite direction of outgoing relationships from the work
+  # i.e. filter cites:W1 means works that cite W1, which when looking at the page for W1
+  # would display as Is Cited By
+  def relationship_label(relationship:)
+    relationship == 'cites' ? 'IsCitedBy' : 'Cites'
+  end
+
+  def map_record_related_dois
+    return [] if @mapped_record['related_identifiers'].blank?
+
+    @mapped_record['related_identifiers'].filter_map do |info|
+      info['related_identifier'] if info['related_identifier_type'].blank? || info['related_identifier_type'] == 'DOI'
+    end
+  end
+end

--- a/app/services/stanford_enhancer.rb
+++ b/app/services/stanford_enhancer.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+# Enhances a DataWorks schema metadata record based on the metadata on that record and related sources
+class StanfordEnhancer
+  def initialize(mapped_record:)
+    @mapped_record = mapped_record.with_indifferent_access
+  end
+
+  # Match stanford contributors and creators with Stanford authorrsbased on ORCIDs
+  # Return the enhanced author record
+  def add_stanford_authors
+    # Do we have any ORCIDs?
+    contributors = Array(@mapped_record[:creators]).concat(Array(@mapped_record[:contributors]))
+    contributors.each do |contributor|
+      # Does it have a name section with an identfier
+      name_identifiers = contributor[:name_identifiers] || []
+      # See if Orcid exists
+      orcid = retrieve_metadata_orcid(name_identifiers:)
+
+      if orcid.present?
+        author = retrieve_stanford_author(orcid:)
+        enhance_author(contributor:, author:) if author.present?
+      end
+    end
+    @mapped_record
+  end
+
+  # Add caps profile id and department names
+  def enhance_author(contributor:, author:)
+    # Add cap profile id to the name identifiers
+    cap_identifier = {
+      'name_identifier' => author.cap_profile_id,
+      'name_identifier_scheme' => 'CAP'
+    }
+
+    # Update creators - if ORCID exists there is already a name identifiers block
+    contributor[:name_identifiers] << cap_identifier
+    add_departments(contributor:, departments: author.departments) if author.departments.present?
+  end
+
+  # Add departments to the affiliation section for creator/contributor metadata
+  # If Stanford University does not exist as an affiliation, add that block
+  def add_departments(contributor:, departments:)
+    affiliation_info = {
+      'name' => 'Stanford University',
+      'affiliation_identifier' => 'https://ror.org/00f54p054', 'affiliation_identifier_scheme' => 'ROR',
+      'affiliation_department_name' => departments
+    }.with_indifferent_access
+
+    if contributor[:affiliation].blank?
+      contributor[:affiliation] = [affiliation_info]
+      return
+    end
+
+    # Is there an existing affiliation block for Stanford?
+    affiliation_blocks = contributor[:affiliation].select do |a|
+      a[:name] == 'Stanford University' || a[:affiliation_identifier] == 'https://ror.org/00f54p054'
+    end
+
+    if affiliation_blocks.empty?
+      contributor[:affiliation] << affiliation_info
+    else
+      affiliation_blocks.first[:affiliation_department_name] = departments
+    end
+  end
+
+  # Retrieve the ORCID, if it exists, from the name identifiers block in the metadata
+  def retrieve_metadata_orcid(name_identifiers:)
+    name_identifiers.each do |name_identifier_info|
+      identifier = name_identifier_info['name_identifier']
+      scheme = name_identifier_info['name_identifier_scheme']
+      return identifier if (scheme.present? && scheme == 'ORCID') || identifier.start_with?('https://orcid.org/')
+    end
+
+    nil
+  end
+
+  # Query the Stanford authors table to retrieve the matching author for an ORCID
+  def retrieve_stanford_author(orcid:)
+    # Use the form of the ORCID that starts with "https://orcid.org"
+    orcid = "https://orcid.org/#{orcid}" unless orcid.start_with?('https://orcid.org/')
+    authors = StanfordAuthor.where(orcid:, active: true)
+    authors.count.positive? ? authors.first : nil
+  rescue StandardError
+    nil
+  end
+end

--- a/spec/cassettes/Clients_OpenAlex/_dataset_doi/retrieves_the_dataset.yml
+++ b/spec/cassettes/Clients_OpenAlex/_dataset_doi/retrieves_the_dataset.yml
@@ -1,0 +1,112 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.openalex.org/works/https://doi.org/10.7910/dvn/qj9rlj
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v2.14.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 20 Nov 2025 22:32:38 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 9a1b675c8b01e675-DEN
+      Cf-Cache-Status:
+      - DYNAMIC
+      Access-Control-Allow-Origin:
+      - "*"
+      Vary:
+      - accept-encoding
+      Server:
+      - cloudflare
+      Via:
+      - 1.1 heroku-router
+      Access-Control-Allow-Headers:
+      - Accept, Accept-Language, Accept-Encoding, Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, HEAD, POST, OPTIONS
+      Access-Control-Expose-Headers:
+      - Cache-Control, RateLimit-Limit, RateLimit-Remaining, RateLimit-Reset, Retry-After
+      Nel:
+      - '{"report_to":"heroku-nel","response_headers":["Via"],"max_age":3600,"success_fraction":0.01,"failure_fraction":0.1}'
+      Ratelimit-Limit:
+      - '5'
+      Ratelimit-Remaining:
+      - '9'
+      Ratelimit-Reset:
+      - '1'
+      Report-To:
+      - '{"group":"heroku-nel","endpoints":[{"url":"https://nel.heroku.com/reports?s=I4iS1OM6wcazj61nOsxUtlyCpZ7Dhb2sKrQCLHTEsjs%3D\u0026sid=c46efe9b-d3d2-4a0c-8c76-bfafa16c5add\u0026ts=1763677951"}],"max_age":3600}'
+      Reporting-Endpoints:
+      - heroku-nel="https://nel.heroku.com/reports?s=I4iS1OM6wcazj61nOsxUtlyCpZ7Dhb2sKrQCLHTEsjs%3D&sid=c46efe9b-d3d2-4a0c-8c76-bfafa16c5add&ts=1763677951"
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"https://openalex.org/W4398887383","doi":"https://doi.org/10.7910/dvn/qj9rlj","title":"The
+        Face of the Problem: How Subordinates Shield Executives from Blame","display_name":"The
+        Face of the Problem: How Subordinates Shield Executives from Blame","publication_year":2021,"publication_date":"2021-05-11","ids":{"openalex":"https://openalex.org/W4398887383","doi":"https://doi.org/10.7910/dvn/qj9rlj"},"language":"en","primary_location":{"id":"doi:10.7910/dvn/qj9rlj","is_oa":true,"landing_page_url":"https://doi.org/10.7910/dvn/qj9rlj","pdf_url":null,"source":{"id":"https://openalex.org/S4377196806","display_name":"Harvard
+        Dataverse","issn_l":null,"issn":null,"is_oa":false,"is_in_doaj":false,"is_core":false,"host_organization":"https://openalex.org/I136199984","host_organization_name":"Harvard
+        University","host_organization_lineage":["https://openalex.org/I136199984"],"host_organization_lineage_names":[],"type":"repository"},"license":"public-domain","license_id":"https://openalex.org/licenses/public-domain","version":null,"is_accepted":false,"is_published":false,"raw_source_name":null,"raw_type":"dataset"},"type":"dataset","indexed_in":["datacite"],"open_access":{"is_oa":true,"oa_status":"green","oa_url":"https://doi.org/10.7910/dvn/qj9rlj","any_repository_has_fulltext":false},"authorships":[{"author_position":"first","author":{"id":"https://openalex.org/A5023940981","display_name":"Jared
+        McDonald","orcid":"https://orcid.org/0000-0002-2429-271X"},"institutions":[{"id":"https://openalex.org/I97018004","display_name":"Stanford
+        University","ror":"https://ror.org/00f54p054","country_code":"US","type":"education","lineage":["https://openalex.org/I97018004"]}],"countries":["US"],"is_corresponding":false,"raw_author_name":"Jared
+        McDonald","raw_affiliation_strings":["(Stanford University)"],"affiliations":[{"raw_affiliation_string":"(Stanford
+        University)","institution_ids":["https://openalex.org/I97018004"]}]},{"author_position":"middle","author":{"id":"https://openalex.org/A5049691134","display_name":"Sarah
+        E. Croco","orcid":"https://orcid.org/0000-0002-8345-6104"},"institutions":[{"id":"https://openalex.org/I66946132","display_name":"University
+        of Maryland, College Park","ror":"https://ror.org/047s2c258","country_code":"US","type":"education","lineage":["https://openalex.org/I66946132"]}],"countries":["US"],"is_corresponding":false,"raw_author_name":"Sarah
+        E. Croco","raw_affiliation_strings":["(University of Maryland, College Park)"],"affiliations":[{"raw_affiliation_string":"(University
+        of Maryland, College Park)","institution_ids":["https://openalex.org/I66946132"]}]},{"author_position":"last","author":{"id":"https://openalex.org/A5075172061","display_name":"Candace
+        Turitto","orcid":"https://orcid.org/0000-0001-8953-644X"},"institutions":[{"id":"https://openalex.org/I66946132","display_name":"University
+        of Maryland, College Park","ror":"https://ror.org/047s2c258","country_code":"US","type":"education","lineage":["https://openalex.org/I66946132"]}],"countries":["US"],"is_corresponding":false,"raw_author_name":"Candace
+        Turitto","raw_affiliation_strings":["(University of Maryland, College Park)"],"affiliations":[{"raw_affiliation_string":"(University
+        of Maryland, College Park)","institution_ids":["https://openalex.org/I66946132"]}]}],"institutions":[],"countries_distinct_count":1,"institutions_distinct_count":3,"corresponding_author_ids":[],"corresponding_institution_ids":[],"apc_list":null,"apc_paid":null,"fwci":0.0,"has_fulltext":false,"cited_by_count":1,"citation_normalized_percentile":null,"cited_by_percentile_year":null,"biblio":{"volume":null,"issue":null,"first_page":null,"last_page":null},"is_retracted":false,"is_paratext":false,"is_xpac":false,"primary_topic":{"id":"https://openalex.org/T12268","display_name":"Deception
+        detection and forensic psychology","score":0.828000009059906,"subfield":{"id":"https://openalex.org/subfields/3207","display_name":"Social
+        Psychology"},"field":{"id":"https://openalex.org/fields/32","display_name":"Psychology"},"domain":{"id":"https://openalex.org/domains/2","display_name":"Social
+        Sciences"}},"topics":[{"id":"https://openalex.org/T12268","display_name":"Deception
+        detection and forensic psychology","score":0.828000009059906,"subfield":{"id":"https://openalex.org/subfields/3207","display_name":"Social
+        Psychology"},"field":{"id":"https://openalex.org/fields/32","display_name":"Psychology"},"domain":{"id":"https://openalex.org/domains/2","display_name":"Social
+        Sciences"}},{"id":"https://openalex.org/T12965","display_name":"Wildlife Conservation
+        and Criminology Analyses","score":0.7476999759674072,"subfield":{"id":"https://openalex.org/subfields/2309","display_name":"Nature
+        and Landscape Conservation"},"field":{"id":"https://openalex.org/fields/23","display_name":"Environmental
+        Science"},"domain":{"id":"https://openalex.org/domains/3","display_name":"Physical
+        Sciences"}},{"id":"https://openalex.org/T11762","display_name":"Law, Economics,
+        and Judicial Systems","score":0.7282999753952026,"subfield":{"id":"https://openalex.org/subfields/2002","display_name":"Economics
+        and Econometrics"},"field":{"id":"https://openalex.org/fields/20","display_name":"Economics,
+        Econometrics and Finance"},"domain":{"id":"https://openalex.org/domains/2","display_name":"Social
+        Sciences"}}],"keywords":[{"id":"https://openalex.org/keywords/blame","display_name":"Blame","score":0.8988469839096069},{"id":"https://openalex.org/keywords/face","display_name":"Face
+        (sociological concept)","score":0.7456916570663452},{"id":"https://openalex.org/keywords/shield","display_name":"Shield","score":0.5492352247238159},{"id":"https://openalex.org/keywords/psychology","display_name":"Psychology","score":0.490416020154953},{"id":"https://openalex.org/keywords/face-shield","display_name":"Face
+        shield","score":0.4519278407096863},{"id":"https://openalex.org/keywords/management","display_name":"Management","score":0.3877897262573242},{"id":"https://openalex.org/keywords/business","display_name":"Business","score":0.37600404024124146},{"id":"https://openalex.org/keywords/political-science","display_name":"Political
+        science","score":0.3723469376564026},{"id":"https://openalex.org/keywords/public-relations","display_name":"Public
+        relations","score":0.36767905950546265},{"id":"https://openalex.org/keywords/social-psychology","display_name":"Social
+        psychology","score":0.363934725522995},{"id":"https://openalex.org/keywords/geology","display_name":"Geology","score":0.23691532015800476},{"id":"https://openalex.org/keywords/sociology","display_name":"Sociology","score":0.21919235587120056},{"id":"https://openalex.org/keywords/law","display_name":"Law","score":0.20857146382331848},{"id":"https://openalex.org/keywords/economics","display_name":"Economics","score":0.14641648530960083},{"id":"https://openalex.org/keywords/paleontology","display_name":"Paleontology","score":0.07389593124389648},{"id":"https://openalex.org/keywords/social-science","display_name":"Social
+        science","score":0.05606198310852051}],"concepts":[{"id":"https://openalex.org/C2781466463","wikidata":"https://www.wikidata.org/wiki/Q621695","display_name":"Blame","level":2,"score":0.8988469839096069},{"id":"https://openalex.org/C2779304628","wikidata":"https://www.wikidata.org/wiki/Q3503480","display_name":"Face
+        (sociological concept)","level":2,"score":0.7456916570663452},{"id":"https://openalex.org/C138081364","wikidata":"https://www.wikidata.org/wiki/Q852013","display_name":"Shield","level":2,"score":0.5492352247238159},{"id":"https://openalex.org/C15744967","wikidata":"https://www.wikidata.org/wiki/Q9418","display_name":"Psychology","level":0,"score":0.490416020154953},{"id":"https://openalex.org/C2908738153","wikidata":"https://www.wikidata.org/wiki/Q5428384","display_name":"Face
+        shield","level":3,"score":0.4519278407096863},{"id":"https://openalex.org/C187736073","wikidata":"https://www.wikidata.org/wiki/Q2920921","display_name":"Management","level":1,"score":0.3877897262573242},{"id":"https://openalex.org/C144133560","wikidata":"https://www.wikidata.org/wiki/Q4830453","display_name":"Business","level":0,"score":0.37600404024124146},{"id":"https://openalex.org/C17744445","wikidata":"https://www.wikidata.org/wiki/Q36442","display_name":"Political
+        science","level":0,"score":0.3723469376564026},{"id":"https://openalex.org/C39549134","wikidata":"https://www.wikidata.org/wiki/Q133080","display_name":"Public
+        relations","level":1,"score":0.36767905950546265},{"id":"https://openalex.org/C77805123","wikidata":"https://www.wikidata.org/wiki/Q161272","display_name":"Social
+        psychology","level":1,"score":0.363934725522995},{"id":"https://openalex.org/C127313418","wikidata":"https://www.wikidata.org/wiki/Q1069","display_name":"Geology","level":0,"score":0.23691532015800476},{"id":"https://openalex.org/C144024400","wikidata":"https://www.wikidata.org/wiki/Q21201","display_name":"Sociology","level":0,"score":0.21919235587120056},{"id":"https://openalex.org/C199539241","wikidata":"https://www.wikidata.org/wiki/Q7748","display_name":"Law","level":1,"score":0.20857146382331848},{"id":"https://openalex.org/C162324750","wikidata":"https://www.wikidata.org/wiki/Q8134","display_name":"Economics","level":0,"score":0.14641648530960083},{"id":"https://openalex.org/C151730666","wikidata":"https://www.wikidata.org/wiki/Q7205","display_name":"Paleontology","level":1,"score":0.07389593124389648},{"id":"https://openalex.org/C36289849","wikidata":"https://www.wikidata.org/wiki/Q34749","display_name":"Social
+        science","level":1,"score":0.05606198310852051},{"id":"https://openalex.org/C160735492","wikidata":"https://www.wikidata.org/wiki/Q31207","display_name":"Health
+        care","level":2,"score":0.0}],"mesh":[],"locations_count":1,"locations":[{"id":"doi:10.7910/dvn/qj9rlj","is_oa":true,"landing_page_url":"https://doi.org/10.7910/dvn/qj9rlj","pdf_url":null,"source":{"id":"https://openalex.org/S4377196806","display_name":"Harvard
+        Dataverse","issn_l":null,"issn":null,"is_oa":false,"is_in_doaj":false,"is_core":false,"host_organization":"https://openalex.org/I136199984","host_organization_name":"Harvard
+        University","host_organization_lineage":["https://openalex.org/I136199984"],"host_organization_lineage_names":[],"type":"repository"},"license":"public-domain","license_id":"https://openalex.org/licenses/public-domain","version":null,"is_accepted":false,"is_published":null,"raw_source_name":null,"raw_type":"dataset"}],"best_oa_location":{"id":"doi:10.7910/dvn/qj9rlj","is_oa":true,"landing_page_url":"https://doi.org/10.7910/dvn/qj9rlj","pdf_url":null,"source":{"id":"https://openalex.org/S4377196806","display_name":"Harvard
+        Dataverse","issn_l":null,"issn":null,"is_oa":false,"is_in_doaj":false,"is_core":false,"host_organization":"https://openalex.org/I136199984","host_organization_name":"Harvard
+        University","host_organization_lineage":["https://openalex.org/I136199984"],"host_organization_lineage_names":[],"type":"repository"},"license":"public-domain","license_id":"https://openalex.org/licenses/public-domain","version":null,"is_accepted":false,"is_published":false,"raw_source_name":null,"raw_type":"dataset"},"sustainable_development_goals":[],"grants":[],"awards":[],"funders":[],"has_content":{"pdf":false,"grobid_xml":false},"referenced_works_count":0,"referenced_works":[],"related_works":["https://openalex.org/W827416302","https://openalex.org/W3146918773","https://openalex.org/W3135165667","https://openalex.org/W4255463841","https://openalex.org/W4285531584","https://openalex.org/W4252079208","https://openalex.org/W4246005571","https://openalex.org/W4241584525","https://openalex.org/W4253475485","https://openalex.org/W4250294066"],"abstract_inverted_index":{"Though":[0],"avoiding":[1],"blame":[2,20],"is":[3,111,136],"often":[4],"a":[5,39,59,64,125,129],"goal":[6],"of":[7,16,58,92,96,106],"elected":[8],"officials,":[9],"there":[10],"are":[11,24],"relatively":[12],"few":[13],"empirical":[14],"examinations":[15],"how":[17,28],"citizens":[18],"assign":[19],"during":[21],"controversies.":[22],"We":[23,61,119],"particularly":[25],"interested":[26],"in":[27,38,76,116,124],"this":[29,100],"process":[30],"works":[31],"when":[32,52,103,142],"an":[33],"executive":[34],"has":[35],"been":[36],"caught":[37],"lie.":[40],"Using":[41],"two":[42],"survey":[43],"experiments,":[44],"we":[45],"examine":[46],"whether":[47],"subordinates":[48],"can":[49],"shield":[50],"executives":[51],"they":[53],"act":[54],"as":[55],"the":[56,68,73,90,112,134,143],"face":[57],"crisis.":[60],"first":[62],"leverage":[63],"real-life":[65],"situation":[66],"involving":[67,128],"family":[69,93],"separation":[70,94],"crisis":[71],"at":[72],"US-Mexico":[74],"border":[75],"2018.":[77],"Respondents":[78],"who":[79],"read":[80],"that":[81,133],"Donald":[82],"Trump":[83],"falsely":[84],"claimed":[85],"he":[86],"could":[87],"not":[88],"end":[89],"practice":[91],"disapprove":[95],"his":[97,148],"dishonesty.":[98],"Yet":[99],"cost":[101],"disappears":[102],"Trump\u2019s":[104],"then-Secretary":[105],"Homeland":[107],"Security,":[108],"Kirstjen":[109],"Nielsen,":[110],"primary":[113],"official":[114],"discussed":[115],"news":[117],"stories.":[118],"then":[120],"replicate":[121],"these":[122],"findings":[123],"fictional":[126],"scenario":[127],"town":[130],"mayor,":[131],"showing":[132],"mayor":[135],"partially":[137],"shielded":[138],"from":[139],"negative":[140],"appraisals":[141],"city":[144],"manager":[145],"lies":[146],"on":[147],"behalf.":[149]},"counts_by_year":[{"year":2021,"cited_by_count":1}],"updated_date":"2025-11-06T06:51:31.235846","created_date":"2025-10-10T00:00:00"}
+
+        '
+  recorded_at: Thu, 20 Nov 2025 22:32:38 GMT
+recorded_with: VCR 6.3.1

--- a/spec/cassettes/Clients_OpenAlex/_query_relationship/retrieves_the_results.yml
+++ b/spec/cassettes/Clients_OpenAlex/_query_relationship/retrieves_the_results.yml
@@ -1,0 +1,127 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.openalex.org/works?cursor=*&filter=cites:W4398887383,type:!dataset%7Cdatabase%7Csoftware&per-page=200&select=id,doi,ids,type
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v2.14.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 20 Nov 2025 22:32:39 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 9a1b6788ff86f4b9-DEN
+      Cf-Cache-Status:
+      - DYNAMIC
+      Access-Control-Allow-Origin:
+      - "*"
+      Vary:
+      - accept-encoding
+      Server:
+      - cloudflare
+      Via:
+      - 1.1 heroku-router
+      Access-Control-Allow-Headers:
+      - Accept, Accept-Language, Accept-Encoding, Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, HEAD, POST, OPTIONS
+      Access-Control-Expose-Headers:
+      - Cache-Control, RateLimit-Limit, RateLimit-Remaining, RateLimit-Reset, Retry-After
+      Nel:
+      - '{"report_to":"heroku-nel","response_headers":["Via"],"max_age":3600,"success_fraction":0.01,"failure_fraction":0.1}'
+      Ratelimit-Limit:
+      - '5'
+      Ratelimit-Remaining:
+      - '9'
+      Ratelimit-Reset:
+      - '1'
+      Report-To:
+      - '{"group":"heroku-nel","endpoints":[{"url":"https://nel.heroku.com/reports?s=OFNVzqGmjrXyNtlCFs9CyjLPd4NPLTtjgDog0bamebk%3D\u0026sid=c46efe9b-d3d2-4a0c-8c76-bfafa16c5add\u0026ts=1763677958"}],"max_age":3600}'
+      Reporting-Endpoints:
+      - heroku-nel="https://nel.heroku.com/reports?s=OFNVzqGmjrXyNtlCFs9CyjLPd4NPLTtjgDog0bamebk%3D&sid=c46efe9b-d3d2-4a0c-8c76-bfafa16c5add&ts=1763677958"
+    body:
+      encoding: ASCII-8BIT
+      string: '{"meta":{"count":1,"db_response_time_ms":1156,"page":null,"per_page":200,"next_cursor":"Ils5OS4wLCAxMSwgJ2h0dHBzOi8vb3BlbmFsZXgub3JnL1czMTcxOTg3MTAzJ10i","groups_count":null},"results":[{"id":"https://openalex.org/W3171987103","doi":"https://doi.org/10.1017/xps.2021.16","ids":{"openalex":"https://openalex.org/W3171987103","doi":"https://doi.org/10.1017/xps.2021.16","mag":"3171987103"},"type":"article"}],"group_by":[]}
+
+        '
+  recorded_at: Thu, 20 Nov 2025 22:32:39 GMT
+- request:
+    method: get
+    uri: https://api.openalex.org/works?cursor=Ils5OS4wLCAxMSwgJ2h0dHBzOi8vb3BlbmFsZXgub3JnL1czMTcxOTg3MTAzJ10i&filter=cites:W4398887383,type:!dataset%7Cdatabase%7Csoftware&per-page=200&select=id,doi,ids,type
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v2.14.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 20 Nov 2025 22:32:42 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 9a1b67926eb9d318-MCI
+      Cf-Cache-Status:
+      - DYNAMIC
+      Access-Control-Allow-Origin:
+      - "*"
+      Vary:
+      - accept-encoding
+      Server:
+      - cloudflare
+      Via:
+      - 1.1 heroku-router
+      Access-Control-Allow-Headers:
+      - Accept, Accept-Language, Accept-Encoding, Authorization, Content-Type
+      Access-Control-Allow-Methods:
+      - GET, HEAD, POST, OPTIONS
+      Access-Control-Expose-Headers:
+      - Cache-Control, RateLimit-Limit, RateLimit-Remaining, RateLimit-Reset, Retry-After
+      Nel:
+      - '{"report_to":"heroku-nel","response_headers":["Via"],"max_age":3600,"success_fraction":0.01,"failure_fraction":0.1}'
+      Ratelimit-Limit:
+      - '5'
+      Ratelimit-Remaining:
+      - '9'
+      Ratelimit-Reset:
+      - '1'
+      Report-To:
+      - '{"group":"heroku-nel","endpoints":[{"url":"https://nel.heroku.com/reports?s=VmLsOR2EOjNbXY4eBNbCWfAFCs8f1qhIEFoiqXKw%2FYE%3D\u0026sid=c46efe9b-d3d2-4a0c-8c76-bfafa16c5add\u0026ts=1763677960"}],"max_age":3600}'
+      Reporting-Endpoints:
+      - heroku-nel="https://nel.heroku.com/reports?s=VmLsOR2EOjNbXY4eBNbCWfAFCs8f1qhIEFoiqXKw%2FYE%3D&sid=c46efe9b-d3d2-4a0c-8c76-bfafa16c5add&ts=1763677960"
+    body:
+      encoding: ASCII-8BIT
+      string: '{"meta":{"count":1,"db_response_time_ms":571,"page":null,"per_page":200,"next_cursor":null,"groups_count":null},"results":[],"group_by":[]}
+
+        '
+  recorded_at: Thu, 20 Nov 2025 22:32:42 GMT
+recorded_with: VCR 6.3.1

--- a/spec/services/clients/open_alex_spec.rb
+++ b/spec/services/clients/open_alex_spec.rb
@@ -43,4 +43,21 @@ RSpec.describe Clients::OpenAlex, :vcr do
         .with(hash_including(params: include(api_key: 'test_api_token'))).exactly(2).times
     end
   end
+
+  describe '.dataset_doi' do
+    let(:dataset) { client.dataset_doi(doi: '10.7910/dvn/qj9rlj') }
+
+    it 'retrieves the dataset' do
+      expect(dataset['id']).to eq('https://openalex.org/W4398887383')
+    end
+  end
+
+  describe '.query_relationship' do
+    let(:results) { client.query_relationship(relationship: 'cites', id: 'W4398887383') }
+
+    it 'retrieves the results' do
+      expect(results.size).to eq(1)
+      expect(results[0]['id']).to eq('https://openalex.org/W3171987103')
+    end
+  end
 end

--- a/spec/services/dataset_transformer_spec.rb
+++ b/spec/services/dataset_transformer_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe DatasetTransformer do
     described_class.call(dataset_records:, load_id:)
   end
 
+  let(:openalex_client) { instance_double(Clients::OpenAlex) }
   let(:dataset_records) { [redivis_dataset_record, datacite_dataset_record] }
   let(:redivis_dataset_record) { create(:dataset_record) }
   let(:datacite_dataset_record) { create(:dataset_record, :datacite) }
@@ -24,6 +25,8 @@ RSpec.describe DatasetTransformer do
     allow(DataworksMappers::Redivis).to receive(:call).and_call_original
     allow(DataworksMappers::Datacite).to receive(:call).and_call_original
     allow(SolrMapper).to receive(:call).and_call_original
+    allow(Clients::OpenAlex).to receive(:new).and_return(openalex_client)
+    allow(openalex_client).to receive(:dataset_doi).and_return({})
   end
 
   it 'transforms' do

--- a/spec/services/metadata_enhancer_spec.rb
+++ b/spec/services/metadata_enhancer_spec.rb
@@ -3,6 +3,8 @@
 require 'rails_helper'
 
 RSpec.describe MetadataEnhancer do
+  let(:openalex_client) { instance_double(Clients::OpenAlex) }
+
   before do
     StanfordAuthor.create!(sunet_id: 123,
                            cap_profile_id: 345,
@@ -13,11 +15,13 @@ RSpec.describe MetadataEnhancer do
                            email: 'test@test.com',
                            active: true,
                            departments: ['Test Department 1', 'Test Department 2'])
+    allow(Clients::OpenAlex).to receive(:new).and_return(openalex_client)
+    allow(openalex_client).to receive(:dataset_doi).and_return({})
   end
 
   context 'when creators or contributors have ORCIDs that map to our Stanford authors table' do
     let(:mapped_record) { JSON.parse(File.read('spec/fixtures/mapped_datasets/full_metadata_mapped.json')) }
-    let(:enhanced_record) { described_class.call(mapped_record:) }
+    let(:enhanced_record) { described_class.call(mapped_record:, doi: '10.1234/5678') }
 
     it 'adds profile id and department name for creators' do
       creator = enhanced_record[:creators][1]
@@ -60,7 +64,7 @@ RSpec.describe MetadataEnhancer do
         ]
       }
     end
-    let(:enhanced_record) { described_class.call(mapped_record:) }
+    let(:enhanced_record) { described_class.call(mapped_record:, doi: '10.1234/5678') }
 
     it 'adds Stanford University affiliation block' do
       creator = enhanced_record[:creators][0]

--- a/spec/services/openalex_enhancer_spec.rb
+++ b/spec/services/openalex_enhancer_spec.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe OpenalexEnhancer do
+  let(:openalex_client) { instance_double(Clients::OpenAlex) }
+  let(:openalex_dataset) do
+    {
+      'id' => 'abc',
+      'doi' => 'testdoi',
+      'referenced_works_count' => references_count,
+      'cited_by_count' => cited_by_count
+    }
+  end
+
+  let(:cites_results) do
+    [{ 'id' => 'https://openalex.org/W3171987103',
+       'ids' => { 'openalex' => 'https://openalex.org/W3171987103',
+                  'doi' => 'https://doi.org/10.1017/xps.2021.16' },
+       'doi' => 'https://doi.org/10.1017/xps.2021.16', 'type' => 'article' }]
+  end
+
+  let(:cited_by_results) do
+    [{ 'id' => 'https://openalex.org/W2163881983',
+       'ids' => { 'openalex' => 'https://openalex.org/W2163881983',
+                  'doi' => 'https://doi.org/10.1111/j.1467-9221.2006.00451.x' },
+       'doi' => 'https://doi.org/10.1111/j.1467-9221.2006.00451.x', 'type' => 'article' }]
+  end
+
+  let(:mapped_record) { {} }
+  let(:enhanced_record) { described_class.new(mapped_record:, doi: 'testdoi').add_metadata }
+
+  before do
+    allow(Clients::OpenAlex).to receive(:new).and_return(openalex_client)
+    allow(openalex_client).to receive_messages(dataset_doi: openalex_dataset)
+    allow(openalex_client).to receive(:query_relationship).with(relationship: 'cites',
+                                                                id: 'abc').and_return(cites_results)
+    allow(openalex_client).to receive(:query_relationship).with(relationship: 'cited_by',
+                                                                id: 'abc').and_return(cited_by_results)
+  end
+
+  context 'when the original metadata has no related identifiers but OpenAlex returns related publications' do
+    let(:references_count) { 1 }
+    let(:cited_by_count) { 1 }
+
+    it 'adds related publications to the mapped metadata record' do
+      expect(enhanced_record['related_identifiers']).to include(hash_including('related_identifier' => 'W3171987103',
+                                                                               'related_identifier_type' => 'OpenAlex',
+                                                                               'relation_type' => 'IsCitedBy'))
+      expect(enhanced_record['related_identifiers']).to include(hash_including(
+                                                                  'related_identifier' => 'W2163881983',
+                                                                  'relation_type' => 'Cites',
+                                                                  'related_identifier_type' => 'OpenAlex'
+                                                                ))
+    end
+  end
+
+  context 'when the relationship count is zero' do
+    let(:references_count) { 0 }
+    let(:cited_by_count) { 0 }
+
+    it 'does not add any related publications' do
+      expect(enhanced_record).not_to have_key('related_identifiers')
+    end
+  end
+
+  context 'when the metadata record already has related identifiers with no overlapping dois' do
+    let(:references_count) { 1 }
+    let(:cited_by_count) { 1 }
+    let(:mapped_record) do
+      {
+        'related_identifiers' => [{ 'related_identifier' => 'https://testid' }]
+      }
+    end
+
+    it 'does not add any related publications' do
+      expect(enhanced_record['related_identifiers'].size).to eq(3)
+    end
+  end
+
+  context 'when the metadata record has related identifiers with an overlapping doi' do
+    let(:references_count) { 1 }
+    let(:cited_by_count) { 1 }
+    let(:mapped_record) do
+      {
+        'related_identifiers' => [{ 'related_identifier' => '10.1017/xps.2021.16' }]
+      }
+    end
+    let(:overlap_doi) do
+      {
+        'related_identifer' => 'W3171987103',
+        'related_identifier_type' => 'OpenAlex',
+        'relation_type' => 'IsCitedBy'
+      }
+    end
+
+    it 'does not add any related publications' do
+      expect(enhanced_record['related_identifiers']).not_to include(hash_including(overlap_doi))
+    end
+  end
+end


### PR DESCRIPTION
… metadata

Closes #469 

What this PR does:
- Some refactoring in the enhance metadata section, to have the stanford author actions in their own class/module. 
- Queries OpenAlex for each DOI to see if an equivalent OpenAlex record exists
- If the counts for referenced works or cited by works is > 0, then for each category of relationship, we query OpenAlex for those related works, and add the IDs to the metadata