### PR TITLE
Don't index items published from SDR immediately

### DIFF
--- a/app/consumers/sdr_consumer.rb
+++ b/app/consumers/sdr_consumer.rb
@@ -17,30 +17,16 @@ class SdrConsumer < Racecar::Consumer
     'Remote sensing imagery'
   ].freeze
 
-  # Map a single Cocina record to a Solr document
-  # @param cocina_record [CocinaDisplay::CocinaRecord]
-  # @return [Hash] Solr document
-  def self.map_record(cocina_record)
-    dataworks_record = DataworksMappers::Sdr.call(source: cocina_record.cocina_doc)
-    SolrMapper.call(
-      metadata: dataworks_record,
-      doi: cocina_record.doi,
-      id: cocina_record.druid
-    )
-  end
-
   def initialize(
     targets: Settings.purl_fetcher.targets,
     skip_collections: Settings.purl_fetcher.skip_collections,
     cocina_service: CocinaService.new,
-    solr_service: SolrService.new,
     logger: Rdkafka::Config.logger
   )
     super()
     @targets = targets.map(&:downcase)
     @skip_collections = skip_collections.map { |druid| "druid:#{druid}" }
     @cocina_service = cocina_service
-    @solr_service = solr_service
     @logger = logger
   end
 
@@ -49,20 +35,9 @@ class SdrConsumer < Racecar::Consumer
     @change = JSON.parse(message.value) if message.value.present?
     @druid = message.key.delete_prefix('druid:')
     @logger.debug { "SDR indexer received message for druid:#{@druid}: #{@change}" }
+
+    # If it was a deletion or unrelease, do that first
     return process_delete if should_delete?
-
-    update_item
-  rescue DataworksMappers::MappingError => e
-    context = { druid: @druid, record: cocina_record&.cocina_doc }
-    Honeybadger.notify(e, context: context)
-    SdrEvents.report_indexing_errored(@druid, target: 'Dataworks', message: e.message, context: context)
-  end
-
-  # Add or update the item in the index, if possible
-  # NOTE: You can use this in development to manually update an item by running:
-  # SdrConsumer.new.update_item('xx123yy4567')
-  def update_item(druid = nil)
-    @druid ||= druid
 
     # If the item's release targets don't match ours, skip it and don't bother
     # notifying SDR, since it wasn't expected to be indexed anyway
@@ -71,6 +46,14 @@ class SdrConsumer < Racecar::Consumer
       return
     end
 
+    update_item
+  end
+
+  # Add or update an item in the database by druid, if possible
+  # NOTE: You can use this in development to manually update an item by running:
+  # SdrConsumer.new.update_item('xx123yy4567')
+  def update_item(druid = nil)
+    @druid ||= druid
     should_skip? ? process_skip : process_update
   end
 
@@ -159,22 +142,18 @@ class SdrConsumer < Racecar::Consumer
     @logger.info { "SDR indexer skipped druid:#{@druid}; #{skip_reason}" }
   end
 
-  # Remove item from the database and index and notify SDR
+  # Remove item from the database and notify SDR
   def process_delete
     DatasetRecord.destroy_by(provider: 'sdr', dataset_id: @druid)
-    @solr_service.delete(id: @druid)
-    @solr_service.commit
     @logger.info { "SDR indexer deleted druid:#{@druid}" }
-    SdrEvents.report_indexing_deleted(@druid, target: 'Dataworks')
+    SdrEvents.report_indexing_deletion_scheduled(@druid, target: 'Dataworks')
   end
 
-  # Add/update item in the database and index and notify SDR
+  # Add/update item in the database and notify SDR
   def process_update
     update_dataset_record
-    @solr_service.add(solr_doc: SdrConsumer.map_record(cocina_record))
-    @solr_service.commit
     @logger.info { "SDR indexer updated druid:#{@druid}" }
-    SdrEvents.report_indexing_success(@druid, target: 'Dataworks')
+    SdrEvents.report_indexing_scheduled(@druid, target: 'Dataworks')
   end
 end
 # rubocop:enable Metrics/ClassLength

--- a/lib/sdr_events.rb
+++ b/lib/sdr_events.rb
@@ -20,14 +20,14 @@ class SdrEvents
       ::Settings.sdr_events.enabled
     end
 
-    # Item was added/updated in the index
-    def report_indexing_success(druid, target:)
-      create_event(druid:, target:, type: 'indexing_success')
+    # Item will be added/updated in the index
+    def report_indexing_scheduled(druid, target:)
+      create_event(druid:, target:, type: 'indexing_scheduled')
     end
 
-    # Item was removed from the index (e.g. via unrelease)
-    def report_indexing_deleted(druid, target:)
-      create_event(druid:, target:, type: 'indexing_deleted')
+    # Item will be removed from the index (e.g. because of unrelease)
+    def report_indexing_deletion_scheduled(druid, target:)
+      create_event(druid:, target:, type: 'indexing_deletion_scheduled')
     end
 
     # Item has missing or inappropriately formatted metadata

--- a/spec/consumers/sdr_consumer_spec.rb
+++ b/spec/consumers/sdr_consumer_spec.rb
@@ -4,11 +4,7 @@ require 'rails_helper'
 
 RSpec.describe SdrConsumer do
   subject(:consumer) do
-    described_class.new(
-      targets: targets,
-      cocina_service: cocina_service,
-      solr_service: solr_service
-    )
+    described_class.new(targets: targets, cocina_service: cocina_service, logger: logger)
   end
 
   let(:targets) { ['Dataworks'] }
@@ -16,9 +12,9 @@ RSpec.describe SdrConsumer do
   let(:record) { CocinaDisplay::CocinaRecord.new(cocina) }
   let(:message) { instance_double(Racecar::Message, key: 'druid:cz537wr8540', value: message_contents.to_json) }
   let(:message_contents) { { druid: 'druid:cz537wr8540', true_targets: ['Dataworks'] } }
-  let(:solr_service) { instance_double(SolrService, delete: true, add: true, commit: true) }
   let(:cocina_service) { instance_double(CocinaService, cocina_record: record) }
   let(:sdr_set) { DatasetRecordSet.find_or_create_by!(provider: 'sdr', complete: true) }
+  let(:logger) { instance_double(Logger, info: true, debug: true) }
 
   before do
     allow(Settings).to receive_messages(
@@ -26,13 +22,11 @@ RSpec.describe SdrConsumer do
       indexer_group: 'testing_group'
     )
     allow(Honeybadger).to receive(:notify)
-    allow(DataworksMappers::Sdr).to receive(:call).and_call_original
-    allow(SolrMapper).to receive(:call).and_call_original
     allow(SdrEvents).to receive_messages(
-      report_indexing_success: true,
+      report_indexing_scheduled: true,
       report_indexing_skipped: true,
       report_indexing_errored: true,
-      report_indexing_deleted: true
+      report_indexing_deletion_scheduled: true
     )
   end
 
@@ -62,30 +56,18 @@ RSpec.describe SdrConsumer do
       end
     end
 
-    it 'sends the mapped item to Solr' do
-      solr_doc = described_class.map_record(record)
+    it 'notifies SDR' do
       consumer.process(message)
-      expect(solr_service).to have_received(:add).with(solr_doc: solr_doc)
-    end
-
-    it 'notifies SDR of successful indexing' do
-      consumer.process(message)
-      expect(SdrEvents).to have_received(:report_indexing_success).with('cz537wr8540', target: 'Dataworks')
+      expect(SdrEvents).to have_received(:report_indexing_scheduled).with('cz537wr8540', target: 'Dataworks')
     end
 
     context 'with multiple required targets when both targets match' do
       let(:targets) { ['PURL Sitemap', 'Searchworks'] }
       let(:message_contents) { { druid: 'druid:cz537wr8540', true_targets: ['purl sitemap', 'SearchWorks'] } }
 
-      it 'sends the mapped item to Solr' do
-        solr_doc = described_class.map_record(record)
+      it 'notifies SDR' do
         consumer.process(message)
-        expect(solr_service).to have_received(:add).with(solr_doc: solr_doc)
-      end
-
-      it 'notifies SDR of successful indexing' do
-        consumer.process(message)
-        expect(SdrEvents).to have_received(:report_indexing_success).with('cz537wr8540', target: 'Dataworks')
+        expect(SdrEvents).to have_received(:report_indexing_scheduled).with('cz537wr8540', target: 'Dataworks')
       end
     end
 
@@ -95,7 +77,7 @@ RSpec.describe SdrConsumer do
 
       it 'skips indexing; does nothing' do
         consumer.process(message)
-        expect(solr_service).not_to have_received(:add)
+        expect(DatasetRecord.find_by(provider: 'sdr', dataset_id: 'cz537wr8540')).to be_nil
       end
     end
 
@@ -124,14 +106,9 @@ RSpec.describe SdrConsumer do
         end
       end
 
-      it 'removes the item from the index' do
-        consumer.process(message)
-        expect(solr_service).to have_received(:delete).with(id: 'cz537wr8540')
-      end
-
       it 'notifies SDR' do
         consumer.process(message)
-        expect(SdrEvents).to have_received(:report_indexing_deleted).with('cz537wr8540', target: 'Dataworks')
+        expect(SdrEvents).to have_received(:report_indexing_deletion_scheduled).with('cz537wr8540', target: 'Dataworks')
       end
     end
 
@@ -165,25 +142,15 @@ RSpec.describe SdrConsumer do
         end
       end
 
-      it 'removes the item from the index' do
-        consumer.process(message)
-        expect(solr_service).to have_received(:delete).with(id: 'cz537wr8540')
-      end
-
       it 'notifies SDR' do
         consumer.process(message)
-        expect(SdrEvents).to have_received(:report_indexing_deleted).with('cz537wr8540', target: 'Dataworks')
+        expect(SdrEvents).to have_received(:report_indexing_deletion_scheduled).with('cz537wr8540', target: 'Dataworks')
       end
     end
 
     context 'when the item has no public cocina record' do
       before do
         allow(cocina_service).to receive(:cocina_record).and_raise(Faraday::ResourceNotFound)
-      end
-
-      it 'skips indexing' do
-        consumer.process(message)
-        expect(solr_service).not_to have_received(:add)
       end
 
       it 'notifies SDR' do
@@ -200,11 +167,6 @@ RSpec.describe SdrConsumer do
       before do
         # Remove the self-deposit resource type from the item
         cocina['description']['form'][0] = {}
-      end
-
-      it 'skips indexing' do
-        consumer.process(message)
-        expect(solr_service).not_to have_received(:add)
       end
 
       it 'notifies SDR' do
@@ -224,11 +186,6 @@ RSpec.describe SdrConsumer do
         cocina['access']['download'] = 'none'
       end
 
-      it 'skips indexing' do
-        consumer.process(message)
-        expect(solr_service).not_to have_received(:add)
-      end
-
       it 'notifies SDR' do
         consumer.process(message)
         expect(SdrEvents).to have_received(:report_indexing_skipped).with(
@@ -236,18 +193,6 @@ RSpec.describe SdrConsumer do
           target: 'Dataworks',
           message: 'Object rights are dark'
         )
-      end
-    end
-
-    context 'when processing raises an error' do
-      before do
-        allow(DataworksMappers::Sdr).to receive(:call).and_raise(DataworksMappers::MappingError)
-      end
-
-      it 'notifies Honeybadger and SDR' do
-        consumer.process(message)
-        expect(Honeybadger).to have_received(:notify)
-        expect(SdrEvents).to have_received(:report_indexing_errored)
       end
     end
   end

--- a/spec/services/sdr_events_spec.rb
+++ b/spec/services/sdr_events_spec.rb
@@ -11,23 +11,23 @@ RSpec.describe SdrEvents do
     allow(Dor::Event::Client).to receive(:create)
   end
 
-  describe '#report_indexing_success' do
+  describe '#report_indexing_scheduled' do
     it 'creates an event' do
-      described_class.report_indexing_success(druid, target:)
+      described_class.report_indexing_scheduled(druid, target:)
       expect(Dor::Event::Client).to have_received(:create).with(
         druid: "druid:#{druid}",
-        type: 'indexing_success',
+        type: 'indexing_scheduled',
         data: { host: Socket.gethostname, invoked_by: 'dataworks-indexer', target: }
       )
     end
   end
 
-  describe '#report_indexing_deleted' do
+  describe '#report_indexing_deletion_scheduled' do
     it 'creates an event' do
-      described_class.report_indexing_deleted(druid, target:)
+      described_class.report_indexing_deletion_scheduled(druid, target:)
       expect(Dor::Event::Client).to have_received(:create).with(
         druid: "druid:#{druid}",
-        type: 'indexing_deleted',
+        type: 'indexing_deletion_scheduled',
         data: { host: Socket.gethostname, invoked_by: 'dataworks-indexer', target: }
       )
     end


### PR DESCRIPTION
Also updates the naming/messaging sent back to Argo to say
"indexing scheduled" or "deletion scheduled" instead of that we
indexed/deleted immediately.

Closes #486
