### PR TITLE
Add open access from OpenAlex to rights list 

### DIFF
--- a/app/services/openalex_enhancer.rb
+++ b/app/services/openalex_enhancer.rb
@@ -17,6 +17,13 @@ class OpenalexEnhancer
   def add_metadata
     return @mapped_record if @doi.blank? || @openalex_record.blank?
 
+    @mapped_record = add_publications_metadata
+    @mapped_record = add_access
+    @mapped_record
+  end
+
+  # Add publication related information
+  def add_publications_metadata
     @id = @openalex_record['id']
     # Publications this work references. The filter query uses order: works cited_by this work
     cites = related_publications(relationship: 'cited_by', field: 'referenced_works_count')
@@ -71,5 +78,14 @@ class OpenalexEnhancer
     @mapped_record['related_identifiers'].filter_map do |info|
       info['related_identifier'] if info['related_identifier_type'].blank? || info['related_identifier_type'] == 'DOI'
     end
+  end
+
+  # Add access information into the rights list
+  def add_access
+    oa_status = @openalex_record['open_access']['is_oa']
+    oa_rights = oa_status == true ? 'Open access' : 'Not open access'
+    @mapped_record['rights_list'] = [] if @mapped_record['rights_list'].blank?
+    @mapped_record['rights_list'] << { 'rights' => oa_rights }
+    @mapped_record
   end
 end

--- a/spec/services/openalex_enhancer_spec.rb
+++ b/spec/services/openalex_enhancer_spec.rb
@@ -9,7 +9,8 @@ RSpec.describe OpenalexEnhancer do
       'id' => 'abc',
       'doi' => 'testdoi',
       'referenced_works_count' => references_count,
-      'cited_by_count' => cited_by_count
+      'cited_by_count' => cited_by_count,
+      'open_access' => { 'is_oa' => open_access_status }
     }
   end
 
@@ -29,6 +30,7 @@ RSpec.describe OpenalexEnhancer do
 
   let(:mapped_record) { {} }
   let(:enhanced_record) { described_class.new(mapped_record:, doi: 'testdoi').add_metadata }
+  let(:open_access_status) { true }
 
   before do
     allow(Clients::OpenAlex).to receive(:new).and_return(openalex_client)
@@ -96,6 +98,25 @@ RSpec.describe OpenalexEnhancer do
 
     it 'does not add any related publications' do
       expect(enhanced_record['related_identifiers']).not_to include(hash_including(overlap_doi))
+    end
+  end
+
+  context 'when open access status is true' do
+    let(:references_count) { 0 }
+    let(:cited_by_count) { 0 }
+
+    it 'adds open access to the rights list' do
+      expect(enhanced_record['rights_list']).to include({ 'rights' => 'Open access' })
+    end
+  end
+
+  context 'when open access status is false' do
+    let(:references_count) { 0 }
+    let(:cited_by_count) { 0 }
+    let(:open_access_status) { false }
+
+    it 'adds open access to the rights list' do
+      expect(enhanced_record['rights_list']).to include({ 'rights' => 'Not open access' })
     end
   end
 end


### PR DESCRIPTION
Adds open access status (as "Open access" or "Not open access") to the rights list struct for a given dataset.

Addresses one of the options listed in #466 