### PR TITLE
Don't print entire record source JSON in logs/inspect

### DIFF
--- a/app/models/dataset_record.rb
+++ b/app/models/dataset_record.rb
@@ -5,6 +5,10 @@ class DatasetRecord < ApplicationRecord
   has_many :dataset_record_associations, dependent: :destroy
   has_many :dataset_record_sets, through: :dataset_record_associations
 
+  # Don't bother printing the entire source JSON in logs/inspect, as it can
+  # slow things down considerably in a console session
+  self.filter_attributes = [:source]
+
   before_save ->(dataset_record) { dataset_record.source_md5 = Digest::MD5.hexdigest(dataset_record.source.to_json) }
 
   # @return [String] unique identifier for the dataset (independent of the provider)


### PR DESCRIPTION
This causes some queries in a console session to take forever, because
they have to prepare the entire record and then print it to the console.
