### PR TITLE
updating the transformer rake task to catch more errors

### DIFF
--- a/lib/tasks/development.rake
+++ b/lib/tasks/development.rake
@@ -14,8 +14,15 @@ namespace :development do # rubocop:disable Metrics/BlockLength
       dataset_record_set.dataset_records.each do |dataset_record|
         mapper.call(source: dataset_record.source)
       rescue DataworksMappers::MappingError => e
-        puts "#{dataset_record.doi} - Failure message #{e.message}"
+        # Not every dataset has a DOI but all have a dataset id, which may be a DOI
+        puts "#{dataset_record.dataset_id} - Failure message #{e.message}"
+      # Some errors may occur for other reasons, for example, a malformed URI
+      # throwing an error from within Cocina code
+      # We want to capture any errors and output them for tracking
+      rescue StandardError => e
+        puts "#{dataset_record.dataset_id} - Non mapping error #{e.message}"
       end
+
     end
   end
 

--- a/lib/tasks/development.rake
+++ b/lib/tasks/development.rake
@@ -22,7 +22,6 @@ namespace :development do # rubocop:disable Metrics/BlockLength
       rescue StandardError => e
         puts "#{dataset_record.dataset_id} - Non mapping error #{e.message}"
       end
-
     end
   end
 


### PR DESCRIPTION
Relates to #579 .

Updating the rake task to capture things like URI errors will enable the rake task to continue while outputting errors that aren't simply mapping errors.