### PR TITLE
updating searchworks extractor to change query, limit to Stanford

### DIFF
--- a/app/services/extractors/searchworks.rb
+++ b/app/services/extractors/searchworks.rb
@@ -24,7 +24,7 @@ module Extractors
         next unless result.source['marc_json_struct']&.any?
 
         # We need to review the MARC record and retrieve the contributor names and affiliations
-        marc_record ||= MARC::Record.new_from_hash(JSON.parse(result.source['marc_json_struct'][0]))
+        marc_record = MARC::Record.new_from_hash(JSON.parse(result.source['marc_json_struct'][0]))
         stanford_affiliated?(marc_record)
       end
     end
@@ -46,9 +46,12 @@ module Extractors
         # field['a'] has a contributor name. If none exists, we will just skip
         next unless field['a']
 
-        # If the contributor IS an organization, return the
-        organizations << field['a'] if %w[110 710].include? field.tag
-        affiliations << field['u'] if field['u'].present?
+        # If the creator/contributor IS an organization, we save the name directly
+        next unless field['u'].present? && %w[110 710].include?(field.
+                                         # We save affiliations for all creators/contributors where present
+                                         affiliations << field['u'])
+
+        organizations << field['a']
       end
 
       { affiliations: affiliations.uniq, organizations: organizations.uniq }

--- a/app/services/extractors/searchworks.rb
+++ b/app/services/extractors/searchworks.rb
@@ -46,12 +46,10 @@ module Extractors
         # field['a'] has a contributor name. If none exists, we will just skip
         next unless field['a']
 
-        # If the creator/contributor IS an organization, we save the name directly
-        next unless field['u'].present? && %w[110 710].include?(field.
-                                         # We save affiliations for all creators/contributors where present
-                                         affiliations << field['u'])
-
-        organizations << field['a']
+        # If the creator/contributor IS an organization, save the name
+        organizations << field['a'] if %w[110 710].include? field.tag
+        # Save any affiliations for creators or contributors
+        affiliations << field['u'] if field['u'].present?
       end
 
       { affiliations: affiliations.uniq, organizations: organizations.uniq }

--- a/app/services/extractors/searchworks.rb
+++ b/app/services/extractors/searchworks.rb
@@ -12,10 +12,46 @@ module Extractors
     private
 
     def results
-      Enumerator::Chain.new(
+      retain_by_affiliation(Enumerator::Chain.new(
         extra_dataset_results,
         client.list(**list_args).map { |source| source_to_result(source:) }
-      ).uniq(&:id)
+      ).uniq(&:id))
+    end
+
+    # Retain only those results that have a Stanford affiliation
+    def retain_by_affiliation(results_list)
+      results_list.lazy.select do |result|
+        next unless result.source['marc_json_struct']&.any?
+
+        # We need to review the MARC record and retrieve the contributor names and affiliations
+        marc_record ||= MARC::Record.new_from_hash(JSON.parse(result.source['marc_json_struct'][0]))
+        stanford_affiliated?(marc_record)
+      end
+    end
+
+    # Check if record qualifies as Stanford affiliated
+    def stanford_affiliated?(marc_record)
+      relationships = retrieve_affiliations(marc_record)
+      relationships[:organizations].any? { |org| org.downcase.start_with?('stanford') } ||
+        relationships[:affiliations].any? { |affiliation| affiliation.downcase.include?('stanford') }
+    end
+
+    # Retrieve all organization creator or contributor names and creator or contributor affiliations
+    def retrieve_affiliations(marc_record)
+      affiliations = []
+      organizations = []
+
+      # These tags correspond to both creators and contributors
+      marc_record.fields.each_by_tag(%w[100 110 700 710]) do |field|
+        # field['a'] has a contributor name. If none exists, we will just skip
+        next unless field['a']
+
+        # If the contributor IS an organization, return the
+        organizations << field['a'] if %w[110 710].include? field.tag
+        affiliations << field['u'] if field['u'].present?
+      end
+
+      { affiliations: affiliations.uniq, organizations: organizations.uniq }
     end
 
     # Client returns solr docs; we need to map them to ListResults

--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -49,9 +49,7 @@ production:
           query_label: "ICPSR",
           solr_params:
             {
-              q: "Inter-university Consortium for Political and Social Research.",
-              search_field: "search_author",
-              fq: ["access_facet:Online", "format_main_ssim:Dataset"],
+              q: "icpsr AND is4"
             },
         },
       ]

--- a/spec/services/extractors/searchworks_spec.rb
+++ b/spec/services/extractors/searchworks_spec.rb
@@ -7,7 +7,21 @@ RSpec.describe Extractors::Searchworks do
     {
       'id' => '123',
       'last_updated' => '2023-01-01T00:00:00Z',
-      'url_fulltext' => ['http://doi.org/10.3886/ICPSR37620.v1']
+      'url_fulltext' => ['http://doi.org/10.3886/ICPSR37620.v1'],
+      'marc_json_struct' => [
+        '{"fields":[{"700":{"subfields":[{"a":"Prysby, Charles"},{"u":"University of North Carolina-Greensboro"}]}}]}'
+      ]
+    }
+  end
+
+  let(:stanford_doc) do
+    {
+      'id' => '234',
+      'last_updated' => '2023-01-01T00:00:00Z',
+      'url_fulltext' => ['http://doi.org/10.3886/ICPSR37620.v2'],
+      'marc_json_struct' => [
+        '{"fields":[{"700":{"subfields":[{"a":"Prysby, Charles"},{"u":"Stanford University"}]}}]}'
+      ]
     }
   end
 
@@ -29,5 +43,14 @@ RSpec.describe Extractors::Searchworks do
     expect(record.dataset_id).to eq('123')
     expect(record.modified_token).to eq('2023-01-01T00:00:00Z')
     expect(record.doi).to eq('10.3886/ICPSR37620.v1')
+  end
+
+  it 'retains only records that have Stanford affiliation' do
+    list_args = { params: { q: 'test' } }
+    client = instance_double(Clients::Solr, list: [example_doc, stanford_doc], dataset: {})
+    extractor = described_class.new(list_args:, client:, extra_dataset_ids: [])
+    extractor.call
+    expect(DatasetRecord.where(dataset_id: '123')).not_to exist
+    expect(DatasetRecord.where(dataset_id: '234')).to exist
   end
 end

--- a/spec/services/extractors/searchworks_spec.rb
+++ b/spec/services/extractors/searchworks_spec.rb
@@ -36,13 +36,13 @@ RSpec.describe Extractors::Searchworks do
 
   it 'maps solr docs into dataset records' do
     list_args = { params: { q: 'test' } }
-    client = instance_double(Clients::Solr, list: [example_doc], dataset: {})
+    client = instance_double(Clients::Solr, list: [stanford_doc], dataset: {})
     extractor = described_class.new(list_args:, client:, extra_dataset_ids: [])
     extractor.call
     record = DatasetRecord.last
-    expect(record.dataset_id).to eq('123')
+    expect(record.dataset_id).to eq('234')
     expect(record.modified_token).to eq('2023-01-01T00:00:00Z')
-    expect(record.doi).to eq('10.3886/ICPSR37620.v1')
+    expect(record.doi).to eq('10.3886/ICPSR37620.v2')
   end
 
   it 'retains only records that have Stanford affiliation' do


### PR DESCRIPTION
Closes #547 

What this PR does:
a) Updates the scheduled query for SearchWorks in recurring.yml based on information we received regarding what we need to query now
b) Updates the extraction job to check the MARC record for the query results for organization and affiliation info. If a creator or contributor is of type organization, we check if the organization name starts with "Stanford". We also check if the creator or contributors have affiliations that include the word "Stanford". If either condition is true, we will pass along the dataset to be saved in the database. Otherwise, we will not.

Trying this out in the dataworks-dev environment:
The initial query returned 12,019 records.  Out of these, we retain 49.