### PR TITLE
Suppress query

### DIFF
--- a/app/models/dataset_record.rb
+++ b/app/models/dataset_record.rb
@@ -11,8 +11,23 @@ class DatasetRecord < ApplicationRecord
 
   before_save ->(dataset_record) { dataset_record.source_md5 = Digest::MD5.hexdigest(dataset_record.source.to_json) }
 
+  # Adding a scope for suppression by query
+  # JSON queries vary by adapter so we are taking that into account
+  scope :by_publisher, lambda { |name|
+    where(Arel.sql(publisher_query, name))
+  }
+
   # @return [String] unique identifier for the dataset (independent of the provider)
   def external_dataset_id
     doi || [provider, dataset_id].join('-')
+  end
+
+  # @return String query source to be employed based on type of connection
+  def self.publisher_query
+    if connection.adapter_name.match?(/postgres/i)
+      "source #>> '{data,attributes,publisher,name}' = ?"
+    else
+      "source->'$.data.attributes.publisher.name' = ?"
+    end
   end
 end

--- a/app/services/dataset_suppress_query.rb
+++ b/app/services/dataset_suppress_query.rb
@@ -9,7 +9,7 @@ class DatasetSuppressQuery
   end
 
   def suppression_ids
-    ids = suppress_by_settings
+    ids = suppress_by_settings.dup
     ids.concat(suppress_datacite_by_query) if @provider == 'datacite'
 
     ids

--- a/app/services/dataset_suppress_query.rb
+++ b/app/services/dataset_suppress_query.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+# Suppresses particular datasets based on queries and providers
+class DatasetSuppressQuery
+  DATACITE_PUBLISHER = 'Environmental Molecular Sciences Laboratory'
+
+  def initialize(provider:)
+    @provider = provider
+  end
+
+  def suppression_ids
+    ids = suppress_by_settings
+    ids.concat(suppress_datacite_by_query) if @provider == 'datacite'
+
+    ids
+  end
+
+  private
+
+  def suppress_by_settings
+    Settings[@provider]&.suppress || []
+  end
+
+  # Returns ids to be suppressed based on a particular query
+  def suppress_datacite_by_query
+    DatasetRecord.where(provider: @provider).by_publisher(DATACITE_PUBLISHER).pluck(:dataset_id)
+  end
+end

--- a/app/services/dataset_transformer.rb
+++ b/app/services/dataset_transformer.rb
@@ -84,8 +84,7 @@ class DatasetTransformer
   end
 
   def suppress?(dataset_record:)
-    suppress_dataset_ids(provider: dataset_record.provider).include?(dataset_record.dataset_id) || 
-      suppress_by_metadata_filter(dataset_record:)
+    suppress_dataset_ids(provider: dataset_record.provider).include?(dataset_record.dataset_id)
   end
 
   # Ignored datasets are expected to raise mapping errors; if they do not,
@@ -100,34 +99,8 @@ class DatasetTransformer
   # for valid datasets that we nevertheless do not want to index.
   def suppress_dataset_ids(provider:)
     @suppress_dataset_ids ||= {}
-    @suppress_dataset_ids[provider] ||= Settings[provider]&.suppress || []
+    @suppress_dataset_ids[provider] ||= DatasetSuppressQuery.new(provider:).suppression_ids
     @suppress_dataset_ids[provider]
-  end
-
-  # We want to also utilize a metadata filtering suppression method when configured
-  # Each provider can have a metadata path and target value specified in the settings
-  # Anything more complex than a metadata value match will need its own method
-  def suppress_by_metadata_filter(dataset_record:)
-    provider = dataset_record.provider
-    @filter ||= {}
-    @filter[provider] ||=  Settings[provider]&.suppress_filter || {}
-    
-    # If there are no specific metadata path and value pairs to suppress, we will return
-    return unless @filter[provider].present? && @filter[provider]['path'].present? && @filter[provider]['value'].present?
-
-    # Get the particular metadata path and corresponding value we wish to check for
-    value = @filter[provider]['value']
-    keys = @filter[provider]['path'].split(':')
-    metadata = dataset_record.source
-
-    keys.each do |key|
-      break unless metadata.is_a?(Hash)
-
-      metadata = metadata.key?(key) ? metadata[key] : metadata[key.to_sym]
-    end
-   
-    # If the value to suppress is included, we will suppress this dataset
-    return Array(metadata).include?(value) 
   end
 
   def check_mapping_success(dataset_record:)

--- a/app/services/dataset_transformer.rb
+++ b/app/services/dataset_transformer.rb
@@ -3,7 +3,7 @@
 # Performs transformation from source metadata to Solr documents for a single dataset
 class DatasetTransformer
   # These providers are ordered by preference for mapping.
-  PROVIDERS = %w[sdr datacite local searchworks dryad redivis zenodo open_alex].freeze
+  PROVIDERS = %w[sdr datacite local searchworks dryad redivis zenodo].freeze
 
   # These fields are merged from the dataset records of other providers in preference order.
   MERGEABLE_FIELDS = [:variables_tsim].freeze
@@ -16,6 +16,9 @@ class DatasetTransformer
     @dataset_records = dataset_records
     @load_id = load_id
     @mapper_class = mapper_class
+    # We will generate a hash of a list of suppression ids for each provider.
+    # These ids require both reading from Settings and also other queries.
+    @suppress_by_provider = extract_suppression_ids
   end
 
   # @return [Hash] Solr document for the dataset.
@@ -84,7 +87,7 @@ class DatasetTransformer
   end
 
   def suppress?(dataset_record:)
-    suppress_dataset_ids(provider: dataset_record.provider).include?(dataset_record.dataset_id)
+    @suppress_by_provider[dataset_record.provider]&.include?(dataset_record.dataset_id)
   end
 
   # Ignored datasets are expected to raise mapping errors; if they do not,
@@ -97,10 +100,8 @@ class DatasetTransformer
 
   # Suppressed datasets are always skipped without notification; they are used
   # for valid datasets that we nevertheless do not want to index.
-  def suppress_dataset_ids(provider:)
-    @suppress_dataset_ids ||= {}
-    @suppress_dataset_ids[provider] ||= DatasetSuppressQuery.new(provider:).suppression_ids
-    @suppress_dataset_ids[provider]
+  def extract_suppression_ids
+    PROVIDERS.index_with { |provider| DatasetSuppressQuery.new(provider:).suppression_ids.compact }
   end
 
   def check_mapping_success(dataset_record:)

--- a/app/services/dataset_transformer.rb
+++ b/app/services/dataset_transformer.rb
@@ -84,7 +84,8 @@ class DatasetTransformer
   end
 
   def suppress?(dataset_record:)
-    suppress_dataset_ids(provider: dataset_record.provider).include?(dataset_record.dataset_id)
+    suppress_dataset_ids(provider: dataset_record.provider).include?(dataset_record.dataset_id) || 
+      suppress_by_metadata_filter(dataset_record:)
   end
 
   # Ignored datasets are expected to raise mapping errors; if they do not,
@@ -101,6 +102,32 @@ class DatasetTransformer
     @suppress_dataset_ids ||= {}
     @suppress_dataset_ids[provider] ||= Settings[provider]&.suppress || []
     @suppress_dataset_ids[provider]
+  end
+
+  # We want to also utilize a metadata filtering suppression method when configured
+  # Each provider can have a metadata path and target value specified in the settings
+  # Anything more complex than a metadata value match will need its own method
+  def suppress_by_metadata_filter(dataset_record:)
+    provider = dataset_record.provider
+    @filter ||= {}
+    @filter[provider] ||=  Settings[provider]&.suppress_filter || {}
+    
+    # If there are no specific metadata path and value pairs to suppress, we will return
+    return unless @filter[provider].present? && @filter[provider]['path'].present? && @filter[provider]['value'].present?
+
+    # Get the particular metadata path and corresponding value we wish to check for
+    value = @filter[provider]['value']
+    keys = @filter[provider]['path'].split(':')
+    metadata = dataset_record.source
+
+    keys.each do |key|
+      break unless metadata.is_a?(Hash)
+
+      metadata = metadata.key?(key) ? metadata[key] : metadata[key.to_sym]
+    end
+   
+    # If the value to suppress is included, we will suppress this dataset
+    return Array(metadata).include?(value) 
   end
 
   def check_mapping_success(dataset_record:)

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -12,9 +12,6 @@ redivis:
     - ~
   suppress:
     - ~
-  suppress_filter:
-    path: 'owner:fullName'
-    value: 'Some owner'
 
 zenodo:
 #   api_token: ~

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -12,6 +12,9 @@ redivis:
     - ~
   suppress:
     - ~
+  suppress_filter:
+    path: 'owner:fullName'
+    value: 'Some owner'
 
 zenodo:
 #   api_token: ~

--- a/spec/factories/dataset_records.rb
+++ b/spec/factories/dataset_records.rb
@@ -71,5 +71,23 @@ FactoryBot.define do
         }
       end
     end
+
+    trait :datacite_with_publisher do
+      provider { 'datacite' }
+      dataset_id { doi }
+      sequence(:source) do |_n|
+        {
+          data: {
+            id: doi,
+            type: 'dois',
+            attributes: {
+              publisher: {
+                name: 'Environmental Molecular Sciences Laboratory'
+              }
+            }
+          }
+        }
+      end
+    end
   end
 end

--- a/spec/models/dataset_record_spec.rb
+++ b/spec/models/dataset_record_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe DatasetRecord do
     describe '.by_publisher' do
       # Set up record that should be returned
       let(:matching_record) do
-        described_class.create!({ id: 1, dataset_id: '1',
+        described_class.create!({ dataset_id: '1',
                                   provider: 'datacite',
                                   source: { data:
                                           { attributes:
@@ -17,7 +17,7 @@ RSpec.describe DatasetRecord do
       end
       # Set up record that should not be returned
       let(:excluded_record) do
-        described_class.create!({ id: 2, dataset_id: '2',
+        described_class.create!({ dataset_id: '2',
                                   provider: 'datacite',
                                   source: { data:
                                           { attributes:

--- a/spec/models/dataset_record_spec.rb
+++ b/spec/models/dataset_record_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe DatasetRecord do
+  # Test scope methods
+  describe 'scopes' do
+    describe '.by_publisher' do
+      # Set up record that should be returned
+      let(:matching_record) do
+        described_class.create!({ id: 1, dataset_id: '1',
+                                  provider: 'datacite',
+                                  source: { data:
+                                          { attributes:
+                                            { publisher:
+                                              { name: 'Zenodo' } } } } })
+      end
+      # Set up record that should not be returned
+      let(:excluded_record) do
+        described_class.create!({ id: 2, dataset_id: '2',
+                                  provider: 'datacite',
+                                  source: { data:
+                                          { attributes:
+                                            { publisher:
+                                              { name: 'Shamwow' } } } } })
+      end
+
+      it 'returns only records with matching publisher name' do
+        expect(described_class.by_publisher('Zenodo')).to contain_exactly(matching_record)
+      end
+    end
+  end
+end

--- a/spec/services/dataset_suppress_query_spec.rb
+++ b/spec/services/dataset_suppress_query_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe DatasetSuppressQuery do
+  let(:dataset_suppress_query) { described_class.new(provider: provider) }
+
+  describe '#suppression_ids' do
+    context 'when both query and Settings define ids to suppress' do
+      let(:provider) { 'datacite' }
+
+      before do
+        allow(Settings.datacite).to receive(:suppress).and_return(['4'])
+        DatasetRecord.create!({ id: 1, dataset_id: '1',
+                                provider: provider,
+                                source: { data:
+                                        { attributes:
+                                          { publisher:
+                                            { name: 'Environmental Molecular Sciences Laboratory' } } } } })
+
+        DatasetRecord.create!({ id: 3, dataset_id: '3',
+                                provider: provider,
+                                source: { data:
+                                        { attributes:
+                                          { publisher:
+                                            { name: 'Environmental Molecular Sciences Laboratory' } } } } })
+        DatasetRecord.create!({ id: 2, dataset_id: '2',
+                                provider: provider,
+                                source: { data:
+                                        { attributes:
+                                          { publisher:
+                                            { name: 'Shamwow' } } } } })
+      end
+
+      it 'returns ids of records that have a specific publisher' do
+        expect(dataset_suppress_query.suppression_ids).to contain_exactly(
+          '1', '3', '4'
+        )
+      end
+    end
+
+    context 'when settings alone provides ids to suppress' do
+      let(:provider) { 'redivis' }
+
+      before do
+        allow(Settings.redivis).to receive(:suppress).and_return(%w[5 6])
+      end
+
+      it 'returns ids specified in Settings' do
+        expect(dataset_suppress_query.suppression_ids).to contain_exactly(
+          '5', '6'
+        )
+      end
+    end
+  end
+end

--- a/spec/services/dataset_transformer_spec.rb
+++ b/spec/services/dataset_transformer_spec.rb
@@ -93,4 +93,21 @@ RSpec.describe DatasetTransformer do
       expect(Honeybadger).not_to have_received(:notify)
     end
   end
+
+  context 'when there is a provider set of metadata field and value defined for suppressing a dataset' do
+    before do
+      allow(Settings.redivis.suppress_filter).to receive_messages(
+        path: 'owner:fullName',
+        value: 'Test Owner'
+      )
+      allow(Honeybadger).to receive(:notify)
+    end
+
+    let(:dataset_records) { [redivis_dataset_record] }
+
+    it 'skips the dataset without notifying Honeybadger' do
+      expect(solr_doc).to be_nil
+      expect(Honeybadger).not_to have_received(:notify)
+    end
+  end
 end

--- a/spec/services/dataset_transformer_spec.rb
+++ b/spec/services/dataset_transformer_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe DatasetTransformer do
   let(:dataset_records) { [redivis_dataset_record, datacite_dataset_record] }
   let(:redivis_dataset_record) { create(:dataset_record) }
   let(:datacite_dataset_record) { create(:dataset_record, :datacite) }
+  let(:datacite_dataset_publisher_record) { create(:dataset_record, :datacite_with_publisher) }
 
   let(:load_id) { 'abc123' }
 
@@ -94,16 +95,13 @@ RSpec.describe DatasetTransformer do
     end
   end
 
-  context 'when there is a provider set of metadata field and value defined for suppressing a dataset' do
+  context 'when there is a suppressed dataset based on suppression query' do
     before do
-      allow(Settings.redivis.suppress_filter).to receive_messages(
-        path: 'owner:fullName',
-        value: 'Test Owner'
-      )
+      allow(Settings.datacite).to receive(:suppress).and_return([])
       allow(Honeybadger).to receive(:notify)
     end
 
-    let(:dataset_records) { [redivis_dataset_record] }
+    let(:dataset_records) { [datacite_dataset_publisher_record] }
 
     it 'skips the dataset without notifying Honeybadger' do
       expect(solr_doc).to be_nil


### PR DESCRIPTION
Closes #541 

What this PR does:

It adds the ability via DatasetSuppressQuery to create mechanisms for identifying records that have particular metadata fields before we conduct any kind of mapping or validation.

Currently, only one criterion is defined: the publisher name for Datacite records. We have other examples we can address using this same approach in the future (e.g. Redivis owner fields, etc. or more complicated queries if need be).

Since we used to also look at the Settings file for hardcoded identifiers we didn't want to include, we are still supporting that, but that functionality now sits in the DatasetSuppressQuery mechanism.

Question: The JSON query syntax is different for Postgres vs other databases, so there is a check in the code for that, but it is unclear whether or not we should forego that entirely.
Another approach would be to update the database directly by explicitly making the fields we want to exclude on into columns. Doing it only via code offers us some more flexibility as far as not having to change the database structure.