### PR TITLE
updating limit to authorization limit

### DIFF
--- a/app/services/clients/zenodo.rb
+++ b/app/services/clients/zenodo.rb
@@ -10,7 +10,7 @@ module Clients
     # @param affiliation [String] name of the organization
     # @return [Array<Clients::ListResult>] array of ListResults for the datasets
     # @raise [Clients::Error] if the request fails
-    def list(affiliation:, page_size: 250)
+    def list(affiliation:, page_size: 100)
       page = 1
       [].tap do |results|
         while page


### PR DESCRIPTION
Requesting more than the limit allowed for authorized requests (i.e. 100) was resulting in 400 errors