### PR TITLE
Build dataset suppression map once per load instead of per dataset

### DIFF
--- a/app/services/dataset_suppress_query.rb
+++ b/app/services/dataset_suppress_query.rb
@@ -1,28 +1,36 @@
 # frozen_string_literal: true
 
-# Suppresses particular datasets based on queries and providers
+# Suppresses particular datasets based on queries and providers.
+#
+# The public entry point is +suppression_ids_by_provider+, which builds the full
+# provider => ids map in one pass (computed once per load by TransformerLoader and
+# passed to DatasetTransformer, so the suppression queries do not run per dataset).
 class DatasetSuppressQuery
   DATACITE_PUBLISHER = 'Environmental Molecular Sciences Laboratory'
 
-  def initialize(provider:)
-    @provider = provider
+  # @param providers [Array<String>] providers to build suppression ids for
+  # @return [Hash{String => Array<String>}] map of provider to suppressed dataset ids
+  def self.suppression_ids_by_provider(providers:)
+    providers.index_with { |provider| suppression_ids(provider:).compact }
   end
 
-  def suppression_ids
-    ids = suppress_by_settings.dup
-    ids.concat(suppress_datacite_by_query) if @provider == 'datacite'
+  # @param provider [String] the provider to gather suppressed ids for
+  # @return [Array<String>] suppressed dataset ids for the provider
+  def self.suppression_ids(provider:)
+    ids = suppress_by_settings(provider:).dup
+    ids.concat(suppress_datacite_by_query(provider:)) if provider == 'datacite'
 
     ids
   end
 
-  private
-
-  def suppress_by_settings
-    Settings[@provider]&.suppress || []
+  def self.suppress_by_settings(provider:)
+    Settings[provider]&.suppress || []
   end
 
   # Returns ids to be suppressed based on a particular query
-  def suppress_datacite_by_query
-    DatasetRecord.where(provider: @provider).by_publisher(DATACITE_PUBLISHER).pluck(:dataset_id)
+  def self.suppress_datacite_by_query(provider:)
+    DatasetRecord.where(provider:).by_publisher(DATACITE_PUBLISHER).pluck(:dataset_id)
   end
+
+  private_class_method :suppression_ids, :suppress_by_settings, :suppress_datacite_by_query
 end

--- a/app/services/dataset_transformer.rb
+++ b/app/services/dataset_transformer.rb
@@ -12,13 +12,17 @@ class DatasetTransformer
     new(...).call
   end
 
-  def initialize(dataset_records:, load_id:, mapper_class: SolrMapper)
+  # @param dataset_records [Array<DatasetRecord>] the records for a single dataset, one per provider
+  # @param load_id [String] identifier for the current transform/load run
+  # @param suppress_by_provider [Hash{String => Array<String>}] map of provider to
+  #   suppressed dataset ids. Computed once per load by TransformerLoader and passed
+  #   in so the suppression queries do not run once per dataset.
+  # @param mapper_class [Class] the Solr mapper used to build the final document
+  def initialize(dataset_records:, load_id:, suppress_by_provider:, mapper_class: SolrMapper)
     @dataset_records = dataset_records
     @load_id = load_id
     @mapper_class = mapper_class
-    # We will generate a hash of a list of suppression ids for each provider.
-    # These ids require both reading from Settings and also other queries.
-    @suppress_by_provider = extract_suppression_ids
+    @suppress_by_provider = suppress_by_provider
   end
 
   # @return [Hash] Solr document for the dataset.
@@ -86,6 +90,8 @@ class DatasetTransformer
     ignore_dataset_ids(provider: dataset_record.provider).include?(dataset_record.dataset_id)
   end
 
+  # Suppressed datasets are always skipped without notification; they are used
+  # for valid datasets that we nevertheless do not want to index.
   def suppress?(dataset_record:)
     @suppress_by_provider[dataset_record.provider]&.include?(dataset_record.dataset_id)
   end
@@ -96,12 +102,6 @@ class DatasetTransformer
     @ignore_dataset_ids ||= {}
     @ignore_dataset_ids[provider] ||= Settings[provider]&.ignore || []
     @ignore_dataset_ids[provider]
-  end
-
-  # Suppressed datasets are always skipped without notification; they are used
-  # for valid datasets that we nevertheless do not want to index.
-  def extract_suppression_ids
-    PROVIDERS.index_with { |provider| DatasetSuppressQuery.new(provider:).suppression_ids.compact }
   end
 
   def check_mapping_success(dataset_record:)

--- a/app/services/transformer_loader.rb
+++ b/app/services/transformer_loader.rb
@@ -25,6 +25,13 @@ class TransformerLoader
 
   attr_reader :load_id, :mapper_class
 
+  # Suppression ids are computed once per load and passed to each DatasetTransformer,
+  # so the underlying Settings reads and suppression queries do not run per dataset.
+  def suppress_by_provider
+    @suppress_by_provider ||=
+      DatasetSuppressQuery.suppression_ids_by_provider(providers: DatasetTransformer::PROVIDERS)
+  end
+
   def dataset_record_sets
     @dataset_record_sets ||= DatasetRecordSet.select(:extractor, :list_args).group(:extractor, :list_args).pluck(
       :extractor, :list_args
@@ -56,7 +63,7 @@ class TransformerLoader
     list_dataset_ids.each_slice(100) do |dataset_ids|
       # Now run transform on this set of grouped records
       grouped_dataset_records(dataset_ids).each_value do |dataset_records|
-        solr_doc = DatasetTransformer.call(dataset_records:, load_id:, mapper_class:)
+        solr_doc = DatasetTransformer.call(dataset_records:, load_id:, mapper_class:, suppress_by_provider:)
         solr_docs << solr_doc if solr_doc
       rescue DataworksMappers::MappingError
         raise if fail_fast?

--- a/spec/services/dataset_suppress_query_spec.rb
+++ b/spec/services/dataset_suppress_query_spec.rb
@@ -3,54 +3,56 @@
 require 'rails_helper'
 
 RSpec.describe DatasetSuppressQuery do
-  let(:dataset_suppress_query) { described_class.new(provider: provider) }
-
-  describe '#suppression_ids' do
-    context 'when both query and Settings define ids to suppress' do
-      let(:provider) { 'datacite' }
-
+  describe '.suppression_ids_by_provider' do
+    context 'when a provider has both query and Settings ids to suppress' do
       before do
         allow(Settings.datacite).to receive(:suppress).and_return(['4'])
-        DatasetRecord.create!({ id: 1, dataset_id: '1',
-                                provider: provider,
+        DatasetRecord.create!({ dataset_id: '1',
+                                provider: 'datacite',
                                 source: { data:
                                         { attributes:
                                           { publisher:
                                             { name: 'Environmental Molecular Sciences Laboratory' } } } } })
-
-        DatasetRecord.create!({ id: 3, dataset_id: '3',
-                                provider: provider,
+        DatasetRecord.create!({ dataset_id: '3',
+                                provider: 'datacite',
                                 source: { data:
                                         { attributes:
                                           { publisher:
                                             { name: 'Environmental Molecular Sciences Laboratory' } } } } })
-        DatasetRecord.create!({ id: 2, dataset_id: '2',
-                                provider: provider,
+        DatasetRecord.create!({ dataset_id: '2',
+                                provider: 'datacite',
                                 source: { data:
                                         { attributes:
                                           { publisher:
                                             { name: 'Shamwow' } } } } })
       end
 
-      it 'returns ids of records that have a specific publisher' do
-        expect(dataset_suppress_query.suppression_ids).to contain_exactly(
-          '1', '3', '4'
-        )
+      it 'merges query and Settings ids for that provider' do
+        result = described_class.suppression_ids_by_provider(providers: ['datacite'])
+
+        expect(result['datacite']).to contain_exactly('1', '3', '4')
       end
     end
 
-    context 'when settings alone provides ids to suppress' do
-      let(:provider) { 'redivis' }
-
+    context 'when a provider has only Settings ids to suppress' do
       before do
         allow(Settings.redivis).to receive(:suppress).and_return(%w[5 6])
       end
 
-      it 'returns ids specified in Settings' do
-        expect(dataset_suppress_query.suppression_ids).to contain_exactly(
-          '5', '6'
-        )
+      it 'returns the Settings ids for that provider' do
+        result = described_class.suppression_ids_by_provider(providers: ['redivis'])
+
+        expect(result['redivis']).to contain_exactly('5', '6')
       end
+    end
+
+    it 'builds an entry for every provider requested' do
+      allow(Settings.datacite).to receive(:suppress).and_return(['4'])
+      allow(Settings.redivis).to receive(:suppress).and_return(%w[5 6])
+
+      result = described_class.suppression_ids_by_provider(providers: %w[datacite redivis])
+
+      expect(result.keys).to contain_exactly('datacite', 'redivis')
     end
   end
 end

--- a/spec/services/dataset_transformer_spec.rb
+++ b/spec/services/dataset_transformer_spec.rb
@@ -4,7 +4,11 @@ require 'rails_helper'
 
 RSpec.describe DatasetTransformer do
   subject(:solr_doc) do
-    described_class.call(dataset_records:, load_id:)
+    described_class.call(dataset_records:, load_id:, suppress_by_provider:)
+  end
+
+  let(:suppress_by_provider) do
+    DatasetSuppressQuery.suppression_ids_by_provider(providers: DatasetTransformer::PROVIDERS)
   end
 
   let(:openalex_client) { instance_double(Clients::OpenAlex) }

--- a/spec/services/transformer_loader_spec.rb
+++ b/spec/services/transformer_loader_spec.rb
@@ -37,17 +37,29 @@ RSpec.describe TransformerLoader do
       dataset_records: contain_exactly(redivis_dataset_record_set.dataset_records.first,
                                        datacite_dataset_record_set.dataset_records.first),
       load_id: String,
-      mapper_class: SolrMapper
+      mapper_class: SolrMapper,
+      suppress_by_provider: Hash
     ).once
     expect(DatasetTransformer).to have_received(:call).with(
-      dataset_records: [redivis_dataset_record_set.dataset_records.last], load_id: String, mapper_class: SolrMapper
+      dataset_records: [redivis_dataset_record_set.dataset_records.last], load_id: String, mapper_class: SolrMapper,
+      suppress_by_provider: Hash
     ).once
     expect(DatasetTransformer).to have_received(:call).with(
-      dataset_records: [datacite_dataset_record_set.dataset_records.last], load_id: String, mapper_class: SolrMapper
+      dataset_records: [datacite_dataset_record_set.dataset_records.last], load_id: String, mapper_class: SolrMapper,
+      suppress_by_provider: Hash
     ).once
     expect(solr_service).to have_received(:add).with(solr_doc:).exactly(3).times
     expect(solr_service).to have_received(:commit).exactly(2).times # once after add, once after delete
     expect(solr_service).to have_received(:delete_by_query).with(query: '-load_id_ssi:"load123"').once
+  end
+
+  it 'builds the suppression map once per load rather than per dataset' do
+    allow(DatasetSuppressQuery).to receive(:suppression_ids_by_provider).and_return({})
+
+    described_class.call(load_id: 'load123')
+
+    # Three datasets are transformed, but the suppression map is built a single time.
+    expect(DatasetSuppressQuery).to have_received(:suppression_ids_by_provider).once
   end
 
   context 'when there is an error in mapping' do


### PR DESCRIPTION
@hudajkhan for your consideration as a follow up to https://github.com/sul-dlss/dataworks-etl/pull/594

`DatasetTransformer` previously computed its suppression id map in initialize, but it is instantiated once per grouped dataset, so the datacite `by_publisher` suppression query ran once for every dataset in a load.

Move the map-building into `DatasetSuppressQuery.suppression_ids_by_provider`, compute it a single time in `TransformerLoader`, and inject it into each `DatasetTransformer` via a required `suppress_by_provider`: argument.
