### PR TITLE
Normalize descriptions into plain-text and sanitized-HTML fields

### DIFF
--- a/app/services/rich_text_normalizer.rb
+++ b/app/services/rich_text_normalizer.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'cgi'
+
+# Normalizes rich, multi-paragraph text (dataset descriptions) into two Solr
+# representations:
+#   - #to_text: plain text for search — block structure flattened to spaces
+#   - #to_html: sanitized semantic HTML for display (presentational wrapping such
+#     as simple_format is applied at render time, not here)
+#
+# Unlike MarkupNormalizer (single-line values like titles/subjects), this
+# preserves block structure and does NOT collapse all whitespace, so paragraphs
+# and lists survive in the display HTML and read as word boundaries in the text.
+class RichTextNormalizer
+  ALLOWED_TAGS = %w[a b i em strong sub sup p br ul ol li table thead tbody tr th td colgroup col].freeze
+  ALLOWED_ATTRIBUTES = %w[href].freeze
+  SANITIZER = Rails::HTML::SafeListSanitizer.new
+  # Block-level tag ends (and <br>) that should read as a word boundary in text.
+  BLOCK_BOUNDARY = %r{</(?:p|div|li|h[1-6]|tr|blockquote|ul|ol|table|thead|tbody)>|<br\s*/?>}i
+
+  # @return [String, nil] plain text with tags removed and block boundaries
+  #   preserved as single spaces. Blank input is returned unchanged.
+  def self.to_text(value)
+    return value if value.blank?
+
+    boundaried = CGI.unescapeHTML(value.to_s).gsub(BLOCK_BOUNDARY, ' ')
+    Nokogiri::HTML.fragment(boundaried).text.gsub(/\s+/, ' ').strip
+  end
+
+  # @return [String, nil] sanitized semantic HTML: allowlisted tags only, no
+  #   attributes but href, presentational cruft (e.g. <span style=...>) dropped.
+  #   Presentational wrapping (simple_format, the display div) happens at render time.
+  def self.to_html(value)
+    return value if value.blank?
+
+    SANITIZER.sanitize(CGI.unescapeHTML(value.to_s), tags: ALLOWED_TAGS, attributes: ALLOWED_ATTRIBUTES).strip
+  end
+end

--- a/app/services/solr_mapper.rb
+++ b/app/services/solr_mapper.rb
@@ -34,7 +34,6 @@ class SolrMapper
       load_id_ssi: load_id,
       access_ssi: metadata['access'],
       provider_ssi: metadata['provider'],
-      descriptions_tsim: descriptions_field,
       doi_ssi: doi,
       provider_identifier_ssi: provider_identifier_field,
       contributors_ssim: person_or_organization_names_fields('creators', 'contributors'),
@@ -47,9 +46,6 @@ class SolrMapper
       publisher_id_sim: publisher_id_field,
       publication_year_isi: metadata['publication_year'].to_i,
       subjects_ssim: subjects_field,
-      methods_tsim: descriptions_by_type_field(['Methods']),
-      other_descriptions_tsim: descriptions_by_type_field(%w[Other SeriesInformation TableOfContents
-                                                             TechnicalInfo]),
       language_ssi: metadata['language'],
       sizes_ssm: metadata['sizes'],
       formats_ssim: formats_field,
@@ -65,12 +61,30 @@ class SolrMapper
       stanford_contributor_bsi: stanford_contributor?,
       stanford_dataset_bsi: metadata['stanford_project'] || stanford_contributor?,
       department_ssim: department_field
-    }.merge(title_fields).merge(struct_fields).compact_blank
+    }.merge(title_fields).merge(struct_fields).merge(description_fields).compact_blank
   end
   # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
 
   def title_fields
     SolrMappers::Titles.call(metadata:)
+  end
+
+  # Description fields as paired Solr fields: a plain-text *_tsim for search and
+  # a sanitized-HTML *_html_tsm for display. Source text is truncated first (see
+  # descriptions_field / descriptions_by_type_field), then normalized.
+  def description_fields
+    rich_text_fields('descriptions', descriptions_field)
+      .merge(rich_text_fields('methods', descriptions_by_type_field(['Methods'])))
+      .merge(rich_text_fields('other_descriptions',
+                              descriptions_by_type_field(%w[Other SeriesInformation TableOfContents TechnicalInfo])))
+  end
+
+  # @return [Hash] { "#{base}_tsim" => plain text, "#{base}_html_tsm" => sanitized HTML }
+  def rich_text_fields(base, values)
+    {
+      "#{base}_tsim": values.map { |value| RichTextNormalizer.to_text(value) },
+      "#{base}_html_tsm": values.map { |value| RichTextNormalizer.to_html(value) }
+    }
   end
 
   # Retrieve the identifier used by the provider themselves

--- a/spec/services/rich_text_normalizer_spec.rb
+++ b/spec/services/rich_text_normalizer_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe RichTextNormalizer do
+  describe '.to_text' do
+    it 'flattens block boundaries to single spaces' do
+      expect(described_class.to_text('<p>Para one</p><p>Para two</p>')).to eq('Para one Para two')
+    end
+
+    it 'treats <br> as a word boundary' do
+      expect(described_class.to_text('Line one<br>Line two')).to eq('Line one Line two')
+    end
+
+    it 'treats list items as word boundaries' do
+      expect(described_class.to_text('<ul><li>one</li><li>two</li></ul>')).to eq('one two')
+    end
+
+    it 'removes inline markup while keeping the text' do
+      expect(described_class.to_text('H<sub>2</sub>O and <em>italics</em>')).to eq('H2O and italics')
+    end
+
+    it 'decodes HTML entities' do
+      expect(described_class.to_text('R&amp;D budget')).to eq('R&D budget')
+    end
+
+    it 'collapses runs of whitespace' do
+      expect(described_class.to_text("lots   of\n\n  space")).to eq('lots of space')
+    end
+
+    it 'returns a blank string unchanged' do
+      expect(described_class.to_text('')).to eq('')
+    end
+
+    it 'returns nil unchanged' do
+      expect(described_class.to_text(nil)).to be_nil
+    end
+  end
+
+  describe '.to_html' do
+    it 'keeps allowlisted inline tags' do
+      expect(described_class.to_html('<em>italic</em> and H<sub>2</sub>O')).to eq('<em>italic</em> and H<sub>2</sub>O')
+    end
+
+    it 'keeps block structure such as paragraphs' do
+      expect(described_class.to_html('<p>One</p><p>Two</p>')).to eq('<p>One</p><p>Two</p>')
+    end
+
+    it 'drops presentational cruft while keeping the inner text' do
+      expect(described_class.to_html('<p><span style="color:red">styled</span> text</p>')).to eq('<p>styled text</p>')
+    end
+
+    it 'keeps only the href attribute' do
+      expect(described_class.to_html('<a href="http://x" onclick="evil()">link</a>')).to eq('<a href="http://x">link</a>')
+    end
+
+    it 'removes script tags, leaving the surrounding text' do
+      expect(described_class.to_html('<script>alert(1)</script>Safe')).to eq('alert(1)Safe')
+    end
+
+    it 'unwraps a non-allowlisted inline tag, keeping its text' do
+      expect(described_class.to_html('Before <mark>highlighted</mark> after')).to eq('Before highlighted after')
+    end
+
+    it 'strips a non-allowlisted block tag while keeping an allowlisted sibling' do
+      expect(described_class.to_html('<h2>Heading</h2><p>Body</p>')).to eq('Heading<p>Body</p>')
+    end
+
+    it 'returns a blank string unchanged' do
+      expect(described_class.to_html('')).to eq('')
+    end
+
+    it 'returns nil unchanged' do
+      expect(described_class.to_html(nil)).to be_nil
+    end
+  end
+end

--- a/spec/services/solr_mapper_spec.rb
+++ b/spec/services/solr_mapper_spec.rb
@@ -39,6 +39,7 @@ RSpec.describe SolrMapper do
             provider_identifier_ssi: 'stanfordphs.prime_india:016c:v0_1',
             doi_ssi: '10.1234/5678',
             descriptions_tsim: ['My description', 'My abstract'],
+            descriptions_html_tsm: ['My description', 'My abstract'],
             creators_struct_ss: '[{"name":"A. Researcher"},{"name":"B. Researcher","name_type":"Personal","given_name":"B.","family_name":"Researcher","name_identifiers":[{"name_identifier":"https://orcid.org/0000-0001-2345-6789","name_identifier_scheme":"ORCID"}],"affiliation":[{"name":"My institution","affiliation_identifier":"https://ror.org/00f54p054","affiliation_identifier_scheme":"ROR"}]},{"name":"A. Organization"},{"name":"B. Organization","name_type":"Organizational","name_identifiers":[{"name_identifier":"https://ror.org/00f54p054"}],"affiliation":[{"name":"B. Parent Organization"}]}]',
             contributors_ids_sim: ['https://orcid.org/0000-0001-2345-6789', 'https://ror.org/00f54p054'],
             contributors_ssim: ['A. Researcher', 'B. Researcher', 'A. Organization', 'B. Organization', 'A. Contributor', 'B. Contributor'],
@@ -75,6 +76,40 @@ RSpec.describe SolrMapper do
       end
     end
     # rubocop:enable Layout/LineLength
+  end
+
+  context 'with rich-text descriptions of several types' do
+    let(:metadata) do
+      {
+        titles: [{ title: 'My title' }],
+        publication_year: '2023',
+        identifiers: [{ identifier: '10.1234/5678', identifier_type: 'DOI' }],
+        url: 'https://example.com/my-dataset',
+        access: 'Public',
+        provider: 'DataCite',
+        descriptions: [
+          { description: '<p>An <em>abstract</em> with <span style="color:red">markup</span>.</p>' },
+          { description: 'H<sub>2</sub>O sampling steps.', description_type: 'Methods' },
+          { description: 'See <a href="http://x" onclick="bad()">table</a>.', description_type: 'TechnicalInfo' }
+        ]
+      }
+    end
+
+    describe '#call' do
+      subject(:doc) { solr_mapper.call }
+
+      it 'strips markup for the searchable *_tsim fields, split by description family' do
+        expect(doc[:descriptions_tsim]).to eq(['An abstract with markup.'])
+        expect(doc[:methods_tsim]).to eq(['H2O sampling steps.'])
+        expect(doc[:other_descriptions_tsim]).to eq(['See table.'])
+      end
+
+      it 'keeps sanitized HTML for the display *_html_tsm fields, split by description family' do
+        expect(doc[:descriptions_html_tsm]).to eq(['<p>An <em>abstract</em> with markup.</p>'])
+        expect(doc[:methods_html_tsm]).to eq(['H<sub>2</sub>O sampling steps.'])
+        expect(doc[:other_descriptions_html_tsm]).to eq(['See <a href="http://x">table</a>.'])
+      end
+    end
   end
 
   context 'with minimal metadata record' do


### PR DESCRIPTION
Part of https://github.com/sul-dlss/DWExperimentsBlacklight/issues/305

I'll add the Markdown handling later if we decide to do that. This just moves the rich text handling into the indexer to better handle different requirements of search and display.

Add `RichTextNormalizer` and wire it into `SolrMapper` so each description family is indexed as a pair: a plain-text `*_tsim` for search and a sanitized-HTML `*_html_tsm` for display.
- `descriptions_tsim` / `descriptions_html_tsm`
- `methods_tsim` / `methods_html_tsm`
- `other_descriptions_tsim` / `other_descriptions_html_tsm`
`RichTextNormalizer#to_text `flattens block boundaries to spaces for a clean search value; `#to_html` sanitizes to an allowlist of semantic tags (adding `sub`/`sup`, previously dropped) with `href` the only permitted attribute. Sanitizing at index time means the display value is already safe; presentation wrapping (`simple_format`) stays at render. Source text is truncated before normalizing so Nokogiri repairs any tag cut by the length guard.