### PR TITLE
Refactor MetadataCleaner#cleanup_field into a clearer pipeline

### DIFF
--- a/app/services/metadata_cleaner.rb
+++ b/app/services/metadata_cleaner.rb
@@ -28,18 +28,23 @@ class MetadataCleaner
     solr_doc
   end
 
-  # Pass in an array of values for a field and clean up each value
-  # Cleanup: Split out string of subjects into individual subjects;
-  # remove opening and closing parentheses; remove leading or trailing spaces.
+  # Clean up a field's values and return them as a de-duplicated array:
+  # split combined strings into individual values, strip wrapping parentheses
+  # and whitespace from each, then de-duplicate.
   def cleanup_field(field, values)
-    values = [values] unless values.is_a?(Array)
-    delim = quote_delimited(values)
-    delim = semicolon_delimited(delim) if AUTHOR_FIELDS.include?(field)
-    delim = subject_delimited(delim) if field == 'subjects_ssim'
-    trimmed = delim.map { |val| unwrap_parens(val) }
-    trimmed = trimmed.uniq if field == 'subjects_ssim'
+    values = split_values(field, Array.wrap(values))
+    values = values.map { |value| unwrap_parens(value) }
+    values.uniq
+  end
 
-    values.is_a?(Array) ? trimmed : trimmed[0]
+  # Split combined strings into individual values. Every field splits embedded
+  # quoted, comma-separated strings; author fields also split on ";"; subjects
+  # split on their ">" hierarchy.
+  def split_values(field, values)
+    values = quote_delimited(values)
+    values = semicolon_delimited(values) if AUTHOR_FIELDS.include?(field)
+    values = subject_delimited(values) if field == 'subjects_ssim'
+    values
   end
 
   def quote_delimited(values)

--- a/spec/services/metadata_cleaner_spec.rb
+++ b/spec/services/metadata_cleaner_spec.rb
@@ -48,6 +48,15 @@ RSpec.describe MetadataCleaner do
     end
   end
 
+  context 'with duplicate values in a field' do
+    let(:solr_doc) { { 'contributors_ssim' => %w[Winnie Eeyore Winnie] } }
+    let(:cleaned_up_doc) { described_class.call(solr_doc:) }
+
+    it 'dedupes values within a field' do
+      expect(cleaned_up_doc['contributors_ssim']).to eq(%w[Winnie Eeyore])
+    end
+  end
+
   context 'with hierarchical and marked-up subjects (#303)' do
     let(:solr_doc) do
       {


### PR DESCRIPTION
`cleanup_field` now reads as a split, clean, uniq pipeline, with the per-field splitting grouped in a new split_values method instead of conditionals interleaved between reassignments.

- Remove the scalar-return branch: the input was always wrapped to an array, so the `values.is_a?(Array) ? trimmed : trimmed[0]` ternary never reached `trimmed[0]`. Use `Array.wrap` for ensuring an array avoids a crash on a present-but-nil field.
- Apply `uniq` to every field, not just `subjects_ssim`. Duplicate values are noise across all the controlled/facet fields, and dropping the guard simplifies the pipeline. Added a spec for the uniq behavior. Behavior is otherwise unchanged.

