### PR TITLE
return @mapped_record at the end of the rescue if openalex fetch fails

### DIFF
--- a/app/services/openalex_enhancer.rb
+++ b/app/services/openalex_enhancer.rb
@@ -21,10 +21,13 @@ class OpenalexEnhancer
     @mapped_record = add_access
     @mapped_record
   rescue Clients::Error => e
-    # Log any error that might occur with the client
+    # Log any error that might occur with the client, then return the record
+    # un-enhanced so the transform continues (Honeybadger.notify returns a String,
+    # so it must not be the last expression).
     error_msg = "OpenAlex metadata enhancement client error, #{e}"
     Rails.logger.error { error_msg }
     Honeybadger.notify(error_msg)
+    @mapped_record
   end
 
   # Add publication related information

--- a/spec/services/openalex_enhancer_spec.rb
+++ b/spec/services/openalex_enhancer_spec.rb
@@ -57,6 +57,21 @@ RSpec.describe OpenalexEnhancer do
     end
   end
 
+  context 'when the OpenAlex client errors while enhancing' do
+    let(:references_count) { 1 }
+    let(:cited_by_count) { 1 }
+    let(:mapped_record) { { 'creators' => [{ 'name' => 'A. Researcher' }] } }
+
+    before do
+      allow(openalex_client).to receive(:query_relationship).and_raise(Clients::Error)
+      allow(Honeybadger).to receive(:notify)
+    end
+
+    it 'returns the original metadata record so the transform can continue' do
+      expect(enhanced_record).to eq(mapped_record)
+    end
+  end
+
   context 'when the relationship count is zero' do
     let(:references_count) { 0 }
     let(:cited_by_count) { 0 }


### PR DESCRIPTION
fixes: 

```
TransformLoadJob
NoMethodError undefined method 'with_indifferent_access' for an instance of String 
```

when there's an openalex client/fetch error