### PR TITLE
ensuring correct query

### DIFF
--- a/app/models/dataset_record.rb
+++ b/app/models/dataset_record.rb
@@ -11,10 +11,19 @@ class DatasetRecord < ApplicationRecord
 
   before_save ->(dataset_record) { dataset_record.source_md5 = Digest::MD5.hexdigest(dataset_record.source.to_json) }
 
-  # Adding a scope for suppression by query
+  # Adding a scope for suppression by query for publisher in DataCite metadata
   # JSON queries vary by adapter so we are taking that into account
   scope :by_publisher, lambda { |name|
     where(Arel.sql(publisher_query, name))
+  }
+
+  # Adding a scope for suppression by query by returning dataset ids that do
+  # not correspond to particular identifier prefixes
+  # exclude_prefixes: the prefixes we do NOT want the returned list of dataset records to match
+  # in their identifiers list
+  # The metadata paths are Datacite specific
+  scope :by_excluding_prefix, lambda { |exclude_prefixes|
+    where('NOT (source @@ ?::jsonpath)', identifier_jsonpath(exclude_prefixes))
   }
 
   # @return [String] unique identifier for the dataset (independent of the provider)
@@ -23,11 +32,19 @@ class DatasetRecord < ApplicationRecord
   end
 
   # @return String query source to be employed based on type of connection
+  # Query syntax assumes Postgres
   def self.publisher_query
-    if connection.adapter_name.match?(/postgres/i)
-      "source #>> '{data,attributes,publisher,name}' = ?"
-    else
-      "source->'$.data.attributes.publisher.name' = ?"
-    end
+    "source #>> '{data,attributes,publisher,name}' = ?"
+  end
+
+  # @return String query to be executed to return dataset records that
+  # do not have identifiers which match any of the prefixes in exclude_prefixes
+  # Query syntax assumes Postgres
+  def self.identifier_jsonpath(exclude_prefixes)
+    # Create the regular expression string for the prefixes using '|' to signify OR
+    regex_list = exclude_prefixes.map { |prefix| Regexp.escape(prefix) }.join('|')
+    # The following translates into: does there exist identifier values in the
+    # identifiers array that starts with any of the prefixes in the 'exclude_prefixes' array
+    "exists($.data.attributes.identifiers[*].identifier ? (@ like_regex \"^(#{regex_list})\" ) )"
   end
 end

--- a/app/models/dataset_record.rb
+++ b/app/models/dataset_record.rb
@@ -39,12 +39,18 @@ class DatasetRecord < ApplicationRecord
 
   # @return String query to be executed to return dataset records that
   # do not have identifiers which match any of the prefixes in exclude_prefixes
+  # Assumption: Prefixes are the portions before the first "." in the string
   # Query syntax assumes Postgres
   def self.identifier_jsonpath(exclude_prefixes)
     # Create the regular expression string for the prefixes using '|' to signify OR
-    regex_list = exclude_prefixes.map { |prefix| Regexp.escape(prefix) }.join('|')
+    # Regular expression escaping in Ruby is different than what is required for Postgres.
+    # If we want a more general solution for escaping additional characters,
+    # we should keep in mind escaping slashes
+    regex_list = exclude_prefixes.join('|')
     # The following translates into: does there exist identifier values in the
     # identifiers array that starts with any of the prefixes in the 'exclude_prefixes' array
-    "exists($.data.attributes.identifiers[*].identifier ? (@ like_regex \"^(#{regex_list})\" ) )"
+    # regex_list should resemble a pattern like "phs|sdss", and we are matching against phs. or sdss.
+    # Postgres requires four slashes here to escape the dot or period
+    "exists($.data.attributes.identifiers[*].identifier ? (@ like_regex \"^(#{regex_list})\\\\.\" ) )"
   end
 end

--- a/app/services/dataset_suppress_query.rb
+++ b/app/services/dataset_suppress_query.rb
@@ -10,7 +10,7 @@ class DatasetSuppressQuery
   REDIVIS_PUBLISHER = 'Redivis'
   # Identifier prefixes we wish to keep for sul, phsdata, pulse (Doerr), sdss_data_repository (Doerr)
 
-  REDIVIS_PREFIXES = ['sul.', 'phsdata.', 'sdss_data_repository.', 'pulse.'].freeze
+  REDIVIS_PREFIXES = %w[sul phsdata sdss_data_repository pulse].freeze
 
   # @param providers [Array<String>] providers to build suppression ids for
   # @return [Hash{String => Array<String>}] map of provider to suppressed dataset ids

--- a/app/services/dataset_suppress_query.rb
+++ b/app/services/dataset_suppress_query.rb
@@ -6,7 +6,11 @@
 # provider => ids map in one pass (computed once per load by TransformerLoader and
 # passed to DatasetTransformer, so the suppression queries do not run per dataset).
 class DatasetSuppressQuery
-  DATACITE_PUBLISHER = 'Environmental Molecular Sciences Laboratory'
+  EMSL_PUBLISHER = 'Environmental Molecular Sciences Laboratory'
+  REDIVIS_PUBLISHER = 'Redivis'
+  # Identifier prefixes we wish to keep for sul, phsdata, pulse (Doerr), sdss_data_repository (Doerr)
+
+  REDIVIS_PREFIXES = ['sul.', 'phsdata.', 'sdss_data_repository.', 'pulse.'].freeze
 
   # @param providers [Array<String>] providers to build suppression ids for
   # @return [Hash{String => Array<String>}] map of provider to suppressed dataset ids
@@ -18,19 +22,31 @@ class DatasetSuppressQuery
   # @return [Array<String>] suppressed dataset ids for the provider
   def self.suppression_ids(provider:)
     ids = suppress_by_settings(provider:).dup
-    ids.concat(suppress_datacite_by_query(provider:)) if provider == 'datacite'
+    if provider == 'datacite'
+      ids.concat(suppress_by_publisher_query(provider:))
+         .concat(suppress_by_identifier_query(provider:))
+    end
 
-    ids
+    ids.uniq
   end
 
   def self.suppress_by_settings(provider:)
     Settings[provider]&.suppress || []
   end
 
-  # Returns ids to be suppressed based on a particular query
-  def self.suppress_datacite_by_query(provider:)
-    DatasetRecord.where(provider:).by_publisher(DATACITE_PUBLISHER).pluck(:dataset_id)
+  # Returns ids to be suppressed based on a query for publisher
+  # Specific to Datacite as provider
+  def self.suppress_by_publisher_query(provider:)
+    DatasetRecord.where(provider:).by_publisher(EMSL_PUBLISHER).pluck(:dataset_id)
   end
 
-  private_class_method :suppression_ids, :suppress_by_settings, :suppress_datacite_by_query
+  # Returns ids to be suppressed based on Redivis identifier
+  # Specific to Datacite as provider and Redivis as publisher
+  def self.suppress_by_identifier_query(provider:)
+    DatasetRecord.where(provider:).by_publisher(REDIVIS_PUBLISHER)
+                 .by_excluding_prefix(REDIVIS_PREFIXES).pluck(:dataset_id)
+  end
+
+  private_class_method :suppression_ids, :suppress_by_settings, :suppress_by_publisher_query,
+                       :suppress_by_identifier_query
 end

--- a/spec/models/dataset_record_spec.rb
+++ b/spec/models/dataset_record_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe DatasetRecord do
       end
 
       it 'returns only records that do not match provided prefixes' do
-        expect(described_class.by_excluding_prefix(['sul.']).pluck(:dataset_id)).to contain_exactly('4', '5')
+        expect(described_class.by_excluding_prefix(['sul']).pluck(:dataset_id)).to contain_exactly('4', '5')
       end
     end
   end

--- a/spec/models/dataset_record_spec.rb
+++ b/spec/models/dataset_record_spec.rb
@@ -6,17 +6,15 @@ RSpec.describe DatasetRecord do
   # Test scope methods
   describe 'scopes' do
     describe '.by_publisher' do
-      # Set up record that should be returned
-      let(:matching_record) do
+      before do
+        # Set up record that should be returned
         described_class.create!({ dataset_id: '1',
                                   provider: 'datacite',
                                   source: { data:
                                           { attributes:
                                             { publisher:
                                               { name: 'Zenodo' } } } } })
-      end
-      # Set up record that should not be returned
-      let(:excluded_record) do
+        # Set up record that should not be returned
         described_class.create!({ dataset_id: '2',
                                   provider: 'datacite',
                                   source: { data:
@@ -26,7 +24,48 @@ RSpec.describe DatasetRecord do
       end
 
       it 'returns only records with matching publisher name' do
-        expect(described_class.by_publisher('Zenodo')).to contain_exactly(matching_record)
+        expect(described_class.by_publisher('Zenodo').pluck(:dataset_id)).to contain_exactly('1')
+      end
+    end
+
+    describe '.by_excluding_prefix' do
+      before do
+        # Set up records that should have their dataset ids returned by query
+        described_class.create!({ dataset_id: '4',
+                                  provider: 'datacite',
+                                  source: { data:
+                                  {
+                                    attributes:
+                                    {
+                                      publisher: { name: 'Redivis' },
+                                      identifiers: [{ identifier: 'levante.xyz.110' }]
+                                    }
+                                  } } })
+        described_class.create!({ dataset_id: '5',
+                                  provider: 'datacite',
+                                  source: { data:
+                                  {
+                                    attributes:
+                                    {
+                                      publisher: { name: 'Redivis' },
+                                      identifiers: [{ identifier: 'waffle.abc.111' }]
+                                    }
+                                  } } })
+        # This dataset should not be returned as it has the allowed (or excluded from query results) prefix
+        described_class.create!({ dataset_id: '7',
+                                  provider: 'datacite',
+                                  source: { data:
+                                  {
+                                    attributes:
+                                    {
+                                      publisher: { name: 'Redivis' },
+                                      identifiers: [{ identifier: 'sul.xyz.110' }]
+                                    }
+                                  } } })
+      end
+
+      it 'returns only records that do not match provided prefixes' do
+        expect(described_class.by_excluding_prefix(['sul.']).pluck(:dataset_id)).to contain_exactly('4', '5')
       end
     end
   end

--- a/spec/services/dataset_suppress_query_spec.rb
+++ b/spec/services/dataset_suppress_query_spec.rb
@@ -25,12 +25,30 @@ RSpec.describe DatasetSuppressQuery do
                                         { attributes:
                                           { publisher:
                                             { name: 'Shamwow' } } } } })
+        # This dataset should be returned for suppression b/c of Redivis identifier
+        DatasetRecord.create!({ dataset_id: '5',
+                                provider: 'datacite',
+                                source: { data:
+                                        { attributes:
+                                          {
+                                            publisher: { name: 'Redivis' },
+                                            identifiers: [{ identifier: 'levante.xyz' }]
+                                          } } } })
+        # This dataset should not be returned as the identifier is allowed
+        DatasetRecord.create!({ dataset_id: '6',
+                                provider: 'datacite',
+                                source: { data:
+                                        { attributes:
+                                          {
+                                            publisher: { name: 'Redivis' },
+                                            identifiers: [{ identifier: 'sul.xyz' }]
+                                          } } } })
       end
 
       it 'merges query and Settings ids for that provider' do
         result = described_class.suppression_ids_by_provider(providers: ['datacite'])
 
-        expect(result['datacite']).to contain_exactly('1', '3', '4')
+        expect(result['datacite']).to contain_exactly('1', '3', '4', '5')
       end
     end
 

--- a/spec/services/dataset_suppress_query_spec.rb
+++ b/spec/services/dataset_suppress_query_spec.rb
@@ -43,12 +43,23 @@ RSpec.describe DatasetSuppressQuery do
                                             publisher: { name: 'Redivis' },
                                             identifiers: [{ identifier: 'sul.xyz' }]
                                           } } } })
+        # This dataset id should be returned b/c it was for
+        # Datacite provider, Redivis publisher, and has
+        # no identifiers within the metadata
+        DatasetRecord.create!({ dataset_id: '7',
+                                provider: 'datacite',
+                                source: { data:
+                                        { attributes:
+                                          {
+                                            publisher: { name: 'Redivis' },
+                                            identifiers: []
+                                          } } } })
       end
 
       it 'merges query and Settings ids for that provider' do
         result = described_class.suppression_ids_by_provider(providers: ['datacite'])
 
-        expect(result['datacite']).to contain_exactly('1', '3', '4', '5')
+        expect(result['datacite']).to contain_exactly('1', '3', '4', '5', '7')
       end
     end
 


### PR DESCRIPTION
Closes #612 

What this PR does:

a) some test cleanup for the original query
b) a little renaming of some of the methods in dataset_suppress_query for easier readability
c) dropping any non-Postgres alternatives and stating the queries are Postgres specific
d) adds the following scope to dataset record: by_excluding_prefix which returns all the dataset records where the identifier in the source (assumed to be DataCite) metadata does NOT start with the prefixes passed as argument
e) extends dataset suppress query logic to return suppression ids for DataCite which also include any datasets with publisher = Redivis where the identifier prefixes do not start with our allowed list of Redivis prefixes.  Note this approach will also return datasets for suppression where provider = datacite, publisher = Redivis, AND there are no identifier properties specified at all.
f) Adds tests for the new use case 