### PR TITLE
Split affiliations on semicolons

### DIFF
--- a/app/services/affiliation_normalizer.rb
+++ b/app/services/affiliation_normalizer.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+# Normalizes the affiliations on creators and contributors in a DataWorks
+# metadata record. Runs on the dataworks metadata before Solr mapping, so the
+# result flows to BOTH the flat affiliation fields (affiliation_names_sim) and the
+# JSON struct fields (creators_struct_ss/contributors_struct_ss) the show page renders.
+#
+# Two jobs:
+#
+#   1. Strip markup / decode HTML entities from each affiliation name, so e.g.
+#      "King&apos;s College London" no longer displays with a literal entity.
+#   2. Split an affiliation whose name packs several institutions into a single
+#      semicolon-delimited string, but ONLY when the affiliation has no
+#      identifier, so an identifier such as a ROR is never mis-attached to an
+#      institution it does not describe.
+class AffiliationNormalizer
+  # Record fields whose entries carry affiliations.
+  ENTITY_FIELDS = %w[creators contributors].freeze
+
+  def self.call(...)
+    new(...).call
+  end
+
+  def initialize(mapped_record:)
+    @mapped_record = mapped_record.with_indifferent_access
+  end
+
+  # @return [ActiveSupport::HashWithIndifferentAccess] record with affiliations normalized
+  def call
+    ENTITY_FIELDS.each do |field|
+      Array(@mapped_record[field]).each do |entry|
+        next unless entry.is_a?(Hash) && entry['affiliation'].present?
+
+        entry['affiliation'] = Array(entry['affiliation']).flat_map { |affiliation| normalize(affiliation) }
+      end
+    end
+    @mapped_record
+  end
+
+  private
+
+  # @return [Array<Hash>] one or more affiliations derived from the given one
+  def normalize(affiliation)
+    name = MarkupNormalizer.to_text(affiliation['name'])
+    return [affiliation.merge('name' => name)] unless splittable?(affiliation, name)
+
+    name.split(';').map(&:strip).compact_blank.map { |part| { 'name' => part } }
+  end
+
+  # Split only when the name carries a delimiter and there is no identifier that a
+  # split would strand on the wrong institution.
+  def splittable?(affiliation, name)
+    name.present? && name.include?(';') && affiliation['affiliation_identifier'].blank?
+  end
+end

--- a/app/services/dataset_transformer.rb
+++ b/app/services/dataset_transformer.rb
@@ -68,6 +68,10 @@ class DatasetTransformer
     # name fields and the JSON structs receive clean names.
     metadata = NameNormalizer.call(mapped_record: metadata)
 
+    # Clean and split creator/contributor affiliations (semicolon-delimited names
+    # become separate affiliations) before mapping.
+    metadata = AffiliationNormalizer.call(mapped_record: metadata)
+
     # Call the Solr mapper (or vertex related transformation)
     mapper_class.call(metadata:, doi: dataset_record.doi, id: dataset_record.external_dataset_id, load_id:,
                       provider_identifiers_map:)

--- a/spec/services/affiliation_normalizer_spec.rb
+++ b/spec/services/affiliation_normalizer_spec.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe AffiliationNormalizer do
+  subject(:normalized) { described_class.call(mapped_record:) }
+
+  def affiliations_for(field)
+    normalized[field].flat_map { |entry| entry['affiliation'] }
+  end
+
+  context 'with a semicolon-delimited affiliation name and no identifier' do
+    let(:name) { 'Institute of Geography, Heidelberg University; HeiGIT at Heidelberg University' }
+    let(:mapped_record) do
+      { creators: [{ name: 'Smith, Jane', affiliation: [{ 'name' => name }] }] }
+    end
+
+    it 'splits it into one affiliation per institution' do
+      expect(affiliations_for(:creators)).to eq(
+        [{ 'name' => 'Institute of Geography, Heidelberg University' },
+         { 'name' => 'HeiGIT at Heidelberg University' }]
+      )
+    end
+  end
+
+  context 'with a semicolon-delimited name that carries an identifier' do
+    let(:mapped_record) do
+      {
+        creators: [{ name: 'Smith, Jane',
+                     affiliation: [{ 'name' => 'The University of Texas at Austin; Marine Science Institute',
+                                     'affiliation_identifier' => 'https://ror.org/00hj54h04',
+                                     'affiliation_identifier_scheme' => 'ROR' }] }]
+      }
+    end
+
+    it 'leaves it intact so the identifier is not mis-attached' do
+      expect(affiliations_for(:creators)).to eq(
+        [{ 'name' => 'The University of Texas at Austin; Marine Science Institute',
+           'affiliation_identifier' => 'https://ror.org/00hj54h04',
+           'affiliation_identifier_scheme' => 'ROR' }]
+      )
+    end
+  end
+
+  context 'when a semicolon appears only inside an HTML entity' do
+    let(:mapped_record) do
+      { creators: [{ name: 'Smith, Jane', affiliation: [{ 'name' => 'King&apos;s College London' }] }] }
+    end
+
+    it 'decodes the entity without splitting' do
+      expect(affiliations_for(:creators)).to eq([{ 'name' => "King's College London" }])
+    end
+  end
+
+  context 'with markup in an affiliation name' do
+    let(:mapped_record) do
+      { contributors: [{ name: 'Lal, Apoorva', affiliation: [{ 'name' => 'Ecology &amp; Evolution' }] }] }
+    end
+
+    it 'strips markup while keeping ampersands' do
+      expect(affiliations_for(:contributors)).to eq([{ 'name' => 'Ecology & Evolution' }])
+    end
+  end
+
+  context 'with three institutions in one name' do
+    let(:name) do
+      'Heidelberg University; Harvard T.H. Chan School of Public Health; Africa Health Research Institute'
+    end
+    let(:mapped_record) do
+      { creators: [{ name: 'Smith, Jane', affiliation: [{ 'name' => name }] }] }
+    end
+
+    it 'splits on every delimiter and trims whitespace' do
+      expect(affiliations_for(:creators).pluck('name')).to eq(
+        ['Heidelberg University', 'Harvard T.H. Chan School of Public Health', 'Africa Health Research Institute']
+      )
+    end
+  end
+
+  context 'when a creator has no affiliation' do
+    let(:mapped_record) { { creators: [{ name: 'Smith, Jane' }] } }
+
+    it 'returns the creator unchanged' do
+      expect(normalized[:creators]).to eq([{ 'name' => 'Smith, Jane' }])
+    end
+  end
+
+  it 'leaves other person attributes intact' do
+    creator = described_class.call(
+      mapped_record: { creators: [{ name: 'Smith, Jane', name_type: 'Personal',
+                                    affiliation: [{ 'name' => 'Stanford University' }] }] }
+    )[:creators].first
+    expect(creator[:name]).to eq('Smith, Jane')
+    expect(creator[:name_type]).to eq('Personal')
+    expect(creator[:affiliation]).to eq([{ 'name' => 'Stanford University' }])
+  end
+end


### PR DESCRIPTION
After we went to the trouble to move this issue into the UI I decided it was better to address in ETL 🤷 

Fixes https://github.com/sul-dlss/dataworks-ui/issues/322