### PR TITLE
Exclude contributors with certain roles from display and search

### DIFF
--- a/app/services/solr_mapper.rb
+++ b/app/services/solr_mapper.rb
@@ -9,6 +9,22 @@ class SolrMapper
   # but encoding can expand the length, so we are enforcing
   # a smaller length
   TEXT_LIMIT = 32_000
+
+  # Contributor types that should be excluded from the contributor list display
+  # and not searchable/facetable. Excluding them at index time keeps search,
+  # faceting, and display in agreement.
+  # Funder and ContactPerson still surface via their own fields
+  # (funding_references / access_contact), which are unaffected by this filter.
+  EXCLUDED_CONTRIBUTOR_TYPES = %w[
+    ContactPerson
+    Distributor
+    HostingInstitution
+    RegistrationAgency
+    RegistrationAuthority
+    Sponsor
+    Funder
+  ].freeze
+
   def self.call(...)
     new(...).call
   end
@@ -103,7 +119,7 @@ class SolrMapper
   # Get the name IDs for everything in the given fields (creators, contributors)
   def person_or_organization_ids_fields(*fields)
     fields.flat_map do |field|
-      Array(metadata[field]).map do |creator|
+      included_entities_for(field).map do |creator|
         creator['name_identifiers']&.pluck('name_identifier')
       end.flatten.compact
     end.uniq
@@ -212,13 +228,23 @@ class SolrMapper
 
   # Get the names for everything in the given fields (creators, contributors)
   def person_or_organization_names_fields(*fields)
-    fields.flat_map { |field| metadata[field]&.pluck('name') }.compact.uniq
+    fields.flat_map { |field| included_entities_for(field).pluck('name') }.compact.uniq
+  end
+
+  # Entities for a contributor field with the excluded types removed.
+  # This impacts Solr fields derived from contributors.
+  def included_entities_for(field)
+    entities = Array(metadata[field])
+    return entities unless field.to_s == 'contributors'
+
+    entities.reject { |entity| EXCLUDED_CONTRIBUTOR_TYPES.include?(entity['contributor_type']) }
   end
 
   def struct_fields
     %w[creators contributors dates rights_list funding_references
        related_identifiers access_contact].filter_map do |field|
-      [:"#{field}_struct_ss", metadata[field]&.to_json]
+      value = field == 'contributors' ? included_entities_for(field).presence : metadata[field]
+      [:"#{field}_struct_ss", value&.to_json]
     end.to_h
   end
 
@@ -244,21 +270,21 @@ class SolrMapper
 
   # Retrieve affiliation name array given either creator or contributor field
   def affiliation_names_for_role(role)
-    Array(metadata[role]).flat_map do |role_entity|
+    included_entities_for(role).flat_map do |role_entity|
       role_entity['affiliation']&.pluck('name')
     end&.compact
   end
 
   # Retrieve department names for roles
   def affiliation_department_names_for_role(role)
-    Array(metadata[role]).flat_map do |role_entity|
+    included_entities_for(role).flat_map do |role_entity|
       role_entity['affiliation']&.pluck('affiliation_department_name')
     end&.compact&.flatten
   end
 
   # Retrieve affiliation ids array given either creator or contributor field
   def affiliation_ids_for_role(role)
-    Array(metadata[role]).flat_map do |role_entity|
+    included_entities_for(role).flat_map do |role_entity|
       role_entity['affiliation']&.pluck('affiliation_identifier')
     end&.compact
   end

--- a/spec/services/solr_mapper_spec.rb
+++ b/spec/services/solr_mapper_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe SolrMapper do
             funders_ssim: ['My funder', 'My other funder'],
             funders_ids_sim: ['https://ror.org/00f54p054'],
             url_ss: 'https://example.com/my-dataset',
-            contributors_struct_ss: '[{"name":"A. Contributor"},{"name":"B. Contributor","name_type":"Personal","given_name":"B.","family_name":"Contributor","name_identifiers":[{"name_identifier":"https://orcid.org/0000-0001-2345-6789","name_identifier_scheme":"ORCID"}],"affiliation":[{"name":"My contributor institution","affiliation_identifier":"https://ror.org/00f54p054","affiliation_identifier_scheme":"ROR"}],"contributor_type":"DataCollector"},{"name":"A. Organization"},{"name":"B. Organization","name_type":"Organizational","name_identifiers":[{"name_identifier":"https://ror.org/00f54p054"}],"affiliation":[{"name":"B. Parent Organization"}],"contributor_type":"RegistrationAgency"}]',
+            contributors_struct_ss: '[{"name":"A. Contributor"},{"name":"B. Contributor","name_type":"Personal","given_name":"B.","family_name":"Contributor","name_identifiers":[{"name_identifier":"https://orcid.org/0000-0001-2345-6789","name_identifier_scheme":"ORCID"}],"affiliation":[{"name":"My contributor institution","affiliation_identifier":"https://ror.org/00f54p054","affiliation_identifier_scheme":"ROR"}],"contributor_type":"DataCollector"},{"name":"A. Organization"}]',
             dates_struct_ss: '[{"date":"2023-01-01"},{"date":"2023-01-02T19:20:30+01:00"},{"date":"2023-01-03","date_type":"Updated"},{"date":"2022-01-01/2022-12-31"},{"date":"2022-11-25","date_type":"Coverage"},{"date":"1973"},{"date":"2008-06-08T00:00:00Z/2008-07-04T00:00:00Z"},{"date":"2006-12-20T00:00:00.000Z/2023-10-06T23:59:59.999Z"},{"date":"0600-01-01/1800-01-01"}]',
             funding_references_struct_ss: '[{"funder_name":"My funder"},{"funder_name":"My other funder","funder_identifier":"https://ror.org/00f54p054","funder_identifier_type":"ROR","award_number":"123456","award_uri":"https://doi.org/10.1234/5678","award_title":"My award title"}]',
             related_identifiers_struct_ss: '[{"related_identifier":"10.1234/5678"},{"related_identifier":"10.2345/6789","relation_type":"IsCitedBy","resource_type_general":"JournalArticle","related_identifier_type":"DOI"}]',
@@ -581,5 +581,83 @@ RSpec.describe SolrMapper do
       end
     end
     # rubocop:enable Layout/LineLength
+  end
+
+  describe 'excluded contributor types' do
+    context 'when a dataset has an excluded-type contributor alongside included contributors' do
+      let(:metadata) do
+        {
+          titles: [{ title: 'My title' }],
+          publication_year: '2023',
+          identifiers: [{ identifier: '10.1234/5678', identifier_type: 'DOI' }],
+          url: 'https://example.com/my-dataset',
+          access: 'Public',
+          provider: 'DataCite',
+          creators: [{ name: 'A. Creator' }],
+          contributors: [
+            {
+              name: 'A. Contributor',
+              contributor_type: 'DataCollector',
+              name_identifiers: [{ name_identifier: 'https://ror.org/kept' }],
+              affiliation: [{ name: 'Kept Affiliation' }]
+            },
+            {
+              name: 'Excluded Org',
+              contributor_type: 'RegistrationAgency',
+              name_identifiers: [{ name_identifier: 'https://ror.org/excluded' }],
+              affiliation: [{ name: 'Excluded Affiliation' }]
+            }
+          ]
+        }
+      end
+
+      it 'omits the excluded contributor from the searchable, facetable, and struct fields' do
+        expected_struct = [
+          {
+            name: 'A. Contributor',
+            contributor_type: 'DataCollector',
+            name_identifiers: [{ name_identifier: 'https://ror.org/kept' }],
+            affiliation: [{ name: 'Kept Affiliation' }]
+          }
+        ].to_json
+
+        expect(solr_mapper.call).to include(
+          contributors_ssim: ['A. Creator', 'A. Contributor'],
+          contributors_ids_sim: ['https://ror.org/kept'],
+          affiliation_names_sim: ['Kept Affiliation'],
+          contributors_struct_ss: expected_struct
+        )
+      end
+    end
+
+    context 'when the only contributor has an excluded type' do
+      let(:metadata) do
+        {
+          titles: [{ title: 'My title' }],
+          publication_year: '2023',
+          identifiers: [{ identifier: '10.1234/5678', identifier_type: 'DOI' }],
+          url: 'https://example.com/my-dataset',
+          access: 'Public',
+          provider: 'DataCite',
+          contributors: [{ name: 'Excluded', contributor_type: 'Sponsor' }]
+        }
+      end
+
+      it 'omits the contributors struct field' do
+        expect(solr_mapper.call).not_to include(:contributors_struct_ss)
+      end
+    end
+
+    context 'when a contributor with an excluded type is affiliated with Stanford' do
+      let(:metadata) do
+        {
+          contributors: [{ name: 'Stanford University', contributor_type: 'HostingInstitution' }]
+        }
+      end
+
+      it 'does not identify the dataset as having a stanford contributor' do
+        expect(solr_mapper).not_to be_stanford_contributor
+      end
+    end
   end
 end


### PR DESCRIPTION
fixes https://github.com/sul-dlss/dataworks-ui/issues/315

@hudajkhan I don't see a good way to do this on the front end if we want to exclude these contributor types from the search index.