### PR TITLE
Remove pf670qd3191 from SDR exclude list

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -362,7 +362,6 @@ purl_fetcher:
     - zx244rw1154
     - gs860rq5377
     - bw467mm6252
-    - pf670qd3191
     - nr325kt8685
     - wh620hw5859
     - qx298gy3987


### PR DESCRIPTION
fixes #538 