### PR TITLE
excluding Datacite items whose prefixes start with SDR prefix

### DIFF
--- a/app/models/dataset_record.rb
+++ b/app/models/dataset_record.rb
@@ -26,6 +26,13 @@ class DatasetRecord < ApplicationRecord
     where('NOT (source @@ ?::jsonpath)', identifier_jsonpath(exclude_prefixes))
   }
 
+  # Adding a scope to return dataset records whose DOIs start with a given prefix
+  # sanitize_sql_like will properly escape some characters:
+  # See https://api.rubyonrails.org/v7.1/classes/ActiveRecord/Sanitization/ClassMethods.html#method-i-sanitize_sql_like
+  scope :doi_starts_with, lambda { |doi_prefix|
+    where('doi LIKE ?', "#{sanitize_sql_like(doi_prefix)}%")
+  }
+
   # @return [String] unique identifier for the dataset (independent of the provider)
   def external_dataset_id
     doi || [provider, dataset_id].join('-')

--- a/app/services/dataset_suppress_query.rb
+++ b/app/services/dataset_suppress_query.rb
@@ -11,7 +11,7 @@ class DatasetSuppressQuery
   # Identifier prefixes we wish to keep for sul, phsdata, pulse (Doerr), sdss_data_repository (Doerr)
   REDIVIS_PREFIXES = %w[sul phsdata sdss_data_repository pulse].freeze
   # DOI prefix for SDR which we want to exclude for Datacite
-  SDR_PREFIX = '10.25740'
+  SDR_PREFIX = '10.25740/'
 
   # @param providers [Array<String>] providers to build suppression ids for
   # @return [Hash{String => Array<String>}] map of provider to suppressed dataset ids

--- a/app/services/dataset_suppress_query.rb
+++ b/app/services/dataset_suppress_query.rb
@@ -9,8 +9,9 @@ class DatasetSuppressQuery
   EMSL_PUBLISHER = 'Environmental Molecular Sciences Laboratory'
   REDIVIS_PUBLISHER = 'Redivis'
   # Identifier prefixes we wish to keep for sul, phsdata, pulse (Doerr), sdss_data_repository (Doerr)
-
   REDIVIS_PREFIXES = %w[sul phsdata sdss_data_repository pulse].freeze
+  # DOI prefix for SDR which we want to exclude for Datacite
+  SDR_PREFIX = '10.25740'
 
   # @param providers [Array<String>] providers to build suppression ids for
   # @return [Hash{String => Array<String>}] map of provider to suppressed dataset ids
@@ -25,6 +26,7 @@ class DatasetSuppressQuery
     if provider == 'datacite'
       ids.concat(suppress_by_publisher_query(provider:))
          .concat(suppress_by_identifier_query(provider:))
+         .concat(suppress_by_doi_prefix(provider:))
     end
 
     ids.uniq
@@ -47,6 +49,12 @@ class DatasetSuppressQuery
                  .by_excluding_prefix(REDIVIS_PREFIXES).pluck(:dataset_id)
   end
 
+  # Returns ids to be suppressed by DOI prefix
+  # i.e. all dataset records for this provider whose DOI starts with this SDR prefix
+  def self.suppress_by_doi_prefix(provider:)
+    DatasetRecord.where(provider:).doi_starts_with(SDR_PREFIX).pluck(:dataset_id)
+  end
+
   private_class_method :suppression_ids, :suppress_by_settings, :suppress_by_publisher_query,
-                       :suppress_by_identifier_query
+                       :suppress_by_identifier_query, :suppress_by_doi_prefix
 end

--- a/spec/models/dataset_record_spec.rb
+++ b/spec/models/dataset_record_spec.rb
@@ -68,5 +68,24 @@ RSpec.describe DatasetRecord do
         expect(described_class.by_excluding_prefix(['sul']).pluck(:dataset_id)).to contain_exactly('4', '5')
       end
     end
+
+    describe '.doi_starts_with' do
+      before do
+        # Set up record that should be returned
+        described_class.create!({ dataset_id: '1',
+                                  provider: 'datacite',
+                                  doi: '10.1234.1111',
+                                  source: {} })
+        # Set up record that should not be returned
+        described_class.create!({ dataset_id: '2',
+                                  provider: 'redivis',
+                                  doi: '10.2344.1111',
+                                  source: {} })
+      end
+
+      it 'returns only records with matching doi prefix' do
+        expect(described_class.doi_starts_with('10.1234').pluck(:dataset_id)).to contain_exactly('1')
+      end
+    end
   end
 end

--- a/spec/models/dataset_record_spec.rb
+++ b/spec/models/dataset_record_spec.rb
@@ -74,17 +74,17 @@ RSpec.describe DatasetRecord do
         # Set up record that should be returned
         described_class.create!({ dataset_id: '1',
                                   provider: 'datacite',
-                                  doi: '10.1234.1111',
+                                  doi: '10.1234/1111',
                                   source: {} })
         # Set up record that should not be returned
         described_class.create!({ dataset_id: '2',
                                   provider: 'redivis',
-                                  doi: '10.2344.1111',
+                                  doi: '10.2344/1111',
                                   source: {} })
       end
 
       it 'returns only records with matching doi prefix' do
-        expect(described_class.doi_starts_with('10.1234').pluck(:dataset_id)).to contain_exactly('1')
+        expect(described_class.doi_starts_with('10.1234/').pluck(:dataset_id)).to contain_exactly('1')
       end
     end
   end

--- a/spec/services/dataset_suppress_query_spec.rb
+++ b/spec/services/dataset_suppress_query_spec.rb
@@ -54,12 +54,18 @@ RSpec.describe DatasetSuppressQuery do
                                             publisher: { name: 'Redivis' },
                                             identifiers: []
                                           } } } })
+        # This dataset id should be returned because the prefix starts with the SDR prefix we
+        # wish to suppress from DataCite
+        DatasetRecord.create!({ dataset_id: '8',
+                                provider: 'datacite',
+                                doi: '10.25740.1234',
+                                source: {} })
       end
 
       it 'merges query and Settings ids for that provider' do
         result = described_class.suppression_ids_by_provider(providers: ['datacite'])
 
-        expect(result['datacite']).to contain_exactly('1', '3', '4', '5', '7')
+        expect(result['datacite']).to contain_exactly('1', '3', '4', '5', '7', '8')
       end
     end
 

--- a/spec/services/dataset_suppress_query_spec.rb
+++ b/spec/services/dataset_suppress_query_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe DatasetSuppressQuery do
         # wish to suppress from DataCite
         DatasetRecord.create!({ dataset_id: '8',
                                 provider: 'datacite',
-                                doi: '10.25740.1234',
+                                doi: '10.25740/1234',
                                 source: {} })
       end
 


### PR DESCRIPTION
What this PR does:
a) adds scope to dataset record that will return dataset records whose DOI begins with a provided prefix
b) adds method for dataset suppression in the case of the provider being DataCite for suppressing datasets whose DOI begins with "10.25740"

Closes #608 