### PR TITLE
ensuring we don't send in two authentication headers instead of just Dataverse requirement

### DIFF
--- a/app/services/clients/dataverse.rb
+++ b/app/services/clients/dataverse.rb
@@ -4,14 +4,17 @@ module Clients
   # Client for interacting with the Harvard Dataverse API and for retrieving
   # metadata for individual dataset
   class Dataverse < Clients::Base
-    def initialize(api_token:, url: 'https://dataverse.harvard.edu', conn: nil)
-      super(url: url, api_token: api_token, conn: conn)
+    def initialize(dataverse_token:, url: 'https://dataverse.harvard.edu', conn: nil)
+      # Passing in api_token into constructor will pass in Bearer heading
+      # which we do not want in additon to the X-Dataverse-key header
+      @dataverse_token = dataverse_token
+      super(url: url, conn: conn)
     end
 
     # Dataverse prefers we pass in the api token in the X-Dataverse-key header
     def new_conn
       base_conn = super
-      base_conn.headers['X-Dataverse-key'] = api_token
+      base_conn.headers['X-Dataverse-key'] = @dataverse_token
       base_conn
     end
 

--- a/app/services/dataverse_enhancer.rb
+++ b/app/services/dataverse_enhancer.rb
@@ -8,7 +8,7 @@ class DataverseEnhancer
   def initialize(mapped_record:, doi:)
     @mapped_record = mapped_record
     @doi = doi
-    @client = Clients::Dataverse.new(api_token: Settings.dataverse.api_token)
+    @client = Clients::Dataverse.new(dataverse_token: Settings.dataverse.api_token)
     @related_identifiers = map_record_related_identifiers
     @dataverse_record = @client.dataset_doi(doi: @doi) if check_dataverse?
   rescue Clients::Error => e

--- a/spec/services/clients/dataverse_spec.rb
+++ b/spec/services/clients/dataverse_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Clients::Dataverse, :vcr do
-  let(:client) { described_class.new(api_token: Settings.dataverse.api_token) }
+  let(:client) { described_class.new(dataverse_token: Settings.dataverse.api_token) }
 
   describe '.dataset_doi' do
     let(:dataset) { client.dataset_doi(doi: '10.7910/dvn/reqh8f') }


### PR DESCRIPTION
We want to pass in the API token or Dataverse in a specific header custom for Dataverse, but not also pass it in as Bearer. 
This PR ensures we don't pass in the API token into the base client class which will then create a Authorization Bearer heading. 