### PR TITLE
normalizing dois before adding them

### DIFF
--- a/app/services/dataverse_enhancer.rb
+++ b/app/services/dataverse_enhancer.rb
@@ -82,6 +82,9 @@ class DataverseEnhancer
     # We create a mappig if both identifier is available and NOT already in the mapped record
     return unless id_number.present? && !exists_identifier?(id_number, id_type)
 
+    # Normalize id number if it is a doi
+    id_number = normalize_dois(id_number, id_type)
+
     {
       'related_identifier' => id_number,
       'relation_type' => id_relation,
@@ -109,6 +112,9 @@ class DataverseEnhancer
 
   # Are the following identifier/identifier type combo already in the mapped record
   def exists_identifier?(id_number, id_type)
+    # Normalize the id_number first
+    id_number = normalize_dois(id_number, id_type)
+
     # If there are no such identifiers, return false
     # We are using casecmp to handle any variations in cases in alphanumeric ids
     return false unless @related_identifiers.any? { |ri| ri['related_identifier'].casecmp?(id_number) }
@@ -119,5 +125,12 @@ class DataverseEnhancer
     matching_id_type = matching_id_info['related_identifier_type'] || 'DOI'
     # If identifiers are the same, return true if types are also the same
     matching_id_type == map_identifier_type(id_type || 'doi')
+  end
+
+  # Strip away any https://doi.org or doi: prefixes
+  def normalize_dois(id_number, id_type)
+    return id_number unless id_type == 'doi' || id_type.blank?
+
+    id_number.delete_prefix('https://doi.org/').delete_prefix('doi:').strip
   end
 end

--- a/app/services/dataverse_enhancer.rb
+++ b/app/services/dataverse_enhancer.rb
@@ -83,7 +83,7 @@ class DataverseEnhancer
     return unless id_number.present? && !exists_identifier?(id_number, id_type)
 
     # Normalize id number if it is a doi
-    id_number = normalize_dois(id_number, id_type)
+    id_number = normalize_doi(id_number, id_type)
 
     {
       'related_identifier' => id_number,
@@ -113,7 +113,7 @@ class DataverseEnhancer
   # Are the following identifier/identifier type combo already in the mapped record
   def exists_identifier?(id_number, id_type)
     # Normalize the id_number first
-    id_number = normalize_dois(id_number, id_type)
+    id_number = normalize_doi(id_number, id_type)
 
     # If there are no such identifiers, return false
     # We are using casecmp to handle any variations in cases in alphanumeric ids
@@ -128,7 +128,7 @@ class DataverseEnhancer
   end
 
   # Strip away any https://doi.org or doi: prefixes
-  def normalize_dois(id_number, id_type)
+  def normalize_doi(id_number, id_type)
     return id_number unless id_type == 'doi' || id_type.blank?
 
     id_number.delete_prefix('https://doi.org/').delete_prefix('doi:').strip

--- a/spec/services/dataverse_enhancer_spec.rb
+++ b/spec/services/dataverse_enhancer_spec.rb
@@ -6,7 +6,8 @@ RSpec.describe DataverseEnhancer do
   let(:dataverse_client) { instance_double(Clients::Dataverse) }
   let(:mapped_record) { { 'url' => 'https://dataverse.harvard.edu/citation?persistentId=doi:10.7910/DVN/REQH8F' } }
   let(:dataverse_dataset) { JSON.parse(File.read('spec/fixtures/sources/dataverse.json')) }
-  let(:enhanced_record) { described_class.new(mapped_record:, doi: '10.7910/DVN/REQH8F').add_metadata }
+  let(:enhancer) { described_class.new(mapped_record:, doi: '10.7910/DVN/REQH8F') }
+  let(:enhanced_record) { enhancer.add_metadata }
 
   before do
     allow(Clients::Dataverse).to receive(:new).and_return(dataverse_client)
@@ -107,6 +108,27 @@ RSpec.describe DataverseEnhancer do
       expect(enhanced_record['related_identifiers'].size).to eq(4)
       expect(enhanced_record['related_identifiers']).not_to include(hash_including(from_dataverse))
       expect(enhanced_record['related_identifiers']).to include(mapped_record['related_identifiers'].first)
+    end
+  end
+
+  describe '#exists_identifier?' do
+    let(:mapped_record) do
+      { 'url' => 'https://dataverse.harvard.edu/citation?persistentId=doi:10.7910/DVN/REQH8F',
+        'related_identifiers' => [{
+          'related_identifier' => '10.111.1345/1234'
+        }] }
+    end
+
+    context 'when dataverse doi begins with https://doi.org but otherwise matches existing identifier' do
+      it 'identifies overlapping identifier' do
+        expect(enhancer.exists_identifier?('https://doi.org/10.111.1345/1234', 'doi')).to be(true)
+      end
+    end
+
+    context 'when dataverse doi begins with doi: but otherwise matches existing identifier' do
+      it 'identifies overlapping identifier' do
+        expect(enhancer.exists_identifier?('doi:10.111.1345/1234', 'doi')).to be(true)
+      end
     end
   end
 end


### PR DESCRIPTION
Closes #649 

Some of the DOIs we receive from Dataverse metadata have prefixes in front of them.  When we compare against the DOIs already in our related publications identifiers metadata, we want to be comparing without prefixes. 